### PR TITLE
Make lager log to the console for Docker

### DIFF
--- a/config/sys.config
+++ b/config/sys.config
@@ -35,6 +35,7 @@
    {metadata_whitelist, [poc_id]},
    {handlers,
     [
+     {lager_console_backend, [{level, debug}]},
      {lager_file_backend, [{file, "console.log"}, {level, info}]},
      {lager_file_backend, [{file, "error.log"}, {level, error}]}
     ]}


### PR DESCRIPTION
Problem to solve: We want Docker to get any messages from lager. Docker can only read stdout/stderr in our logging framework

Solution: Make lager write to the console. At debug level currently.