### PR TITLE
Add start.sh Docker entrypoint; remove Docker port

### DIFF
--- a/.buildkite/Dockerfile
+++ b/.buildkite/Dockerfile
@@ -1,6 +1,5 @@
 FROM ubuntu:18.04
 
-EXPOSE 8080
 EXPOSE 22222
 
 RUN apt update
@@ -24,3 +23,5 @@ RUN touch /var/helium/blockchain_etl/.env
 COPY .buildkite/scripts/lager_console_setup.pl /
 RUN perl -i lager_console_setup.pl /var/helium/blockchain_etl/releases/0.1.0/sys.config
 RUN rm -f lager_console_setup.pl
+
+COPY .buildkite/scripts/start.sh /

--- a/.buildkite/scripts/start.sh
+++ b/.buildkite/scripts/start.sh
@@ -1,0 +1,11 @@
+#!/bin/bash
+
+set -euo pipefail
+
+/var/helium/blockchain_etl/bin/blockchain_etl escript \
+    bin/psql_migration setup
+sleep 1
+/var/helium/blockchain_etl/bin/blockchain_etl escript \
+    bin/psql_migration -d /var/helium/blockchain_etl/migrations run
+sleep 1
+/var/helium/blockchain_etl/bin/blockchain_etl foreground


### PR DESCRIPTION
Problem to solve: We want to execute migrations automatically when the container starts, and then start the application

Solution: Add a `start.sh` entry point for Docker which implements this  