### PR TITLE
Bump erlang to 22.1.8; fix relx overlays

### DIFF
--- a/.buildkite/hooks/pre-command
+++ b/.buildkite/hooks/pre-command
@@ -4,7 +4,7 @@ set -e
 echo '--- :house_with_garden: Setting up the environment'
 
 . "$HOME/.asdf/asdf.sh"
-asdf local erlang 21.3
+asdf local erlang 22.1.8
 asdf local python 3.7.3
 asdf local ruby 2.6.2
 

--- a/.buildkite/scripts/make_docker.sh
+++ b/.buildkite/scripts/make_docker.sh
@@ -9,7 +9,7 @@ DOCKER_NAME="$(basename $(pwd))_${BUILDKITE_TAG}"
 
 buildkite-agent artifact download $DEB_PKG .
 
-docker build -t helium:$DOCKER_NAME -f .buildkite/scripts/Dockerfile .
+docker build -t helium:$DOCKER_NAME -f .buildkite/Dockerfile .
 docker tag helium:$DOCKER_NAME "$DEV_ECS_REGISTRY_NAME:$DOCKER_NAME"
 docker tag helium:$DOCKER_NAME "$PROD_ECS_REGISTRY_NAME:$DOCKER_NAME"
 

--- a/rebar.config
+++ b/rebar.config
@@ -48,20 +48,6 @@
 
   {extended_start_script, true},
   {include_src, true},
-
-  {overlay,
-   [
-    {copy, "migrations/*.sql", "migrations/"},
-    {copy, "./_build/default/bin/psql_migration", "bin/psql_migration"},
-    {copy, "priv/genesis", "update/genesis"},
-    {copy, "scripts/extensions/genesis", "bin/extensions/genesis"},
-    {copy, "scripts/extensions/info", "bin/extensions/info"},
-    {copy, "./_build/default/lib/blockchain/scripts/extensions/peer", "bin/extensions/peer"},
-    {copy, "./_build/default/lib/blockchain/scripts/extensions/ledger", "bin/extensions/ledger"},
-    {copy, "./_build/default/lib/blockchain/scripts/extensions/trace", "bin/extensions/trace"},
-    {copy, "./_build/default/lib/blockchain/scripts/extensions/txn", "bin/extensions/txn"},
-    {template, "config/vm.args", "{{output_dir}}/releases/{{release_version}}/vm.args"}
-   ]},
   {extended_start_script_hooks,
    [
     {post_start,
@@ -85,6 +71,36 @@
   {prod,
    [
     {relx, [{dev_mode, false},
-            {include_erts, true}]}
-   ]}
- ]}.
+            {include_erts, true},
+            {overlay,
+             [
+              {copy, "migrations/*.sql", "migrations/"},
+              {copy, "./_build/prod/bin/psql_migration", "bin/psql_migration"},
+              {copy, "priv/genesis", "update/genesis"},
+              {copy, "scripts/extensions/genesis", "bin/extensions/genesis"},
+              {copy, "scripts/extensions/info", "bin/extensions/info"},
+              {copy, "./_build/prod/lib/blockchain/scripts/extensions/peer", "bin/extensions/peer"},
+              {copy, "./_build/prod/lib/blockchain/scripts/extensions/ledger", "bin/extensions/ledger"},
+              {copy, "./_build/prod/lib/blockchain/scripts/extensions/trace", "bin/extensions/trace"},
+              {copy, "./_build/prod/lib/blockchain/scripts/extensions/txn", "bin/extensions/txn"},
+              {template, "config/vm.args", "{{output_dir}}/releases/{{release_version}}/vm.args"}
+             ]}
+   ]
+  }
+ ]},
+  {default, [
+              {overlay,
+                 [
+                  {copy, "migrations/*.sql", "migrations/"},
+                  {copy, "./_build/default/bin/psql_migration", "bin/psql_migration"},
+                  {copy, "priv/genesis", "update/genesis"},
+                  {copy, "scripts/extensions/genesis", "bin/extensions/genesis"},
+                  {copy, "scripts/extensions/info", "bin/extensions/info"},
+                  {copy, "./_build/default/lib/blockchain/scripts/extensions/peer", "bin/extensions/peer"},
+                  {copy, "./_build/default/lib/blockchain/scripts/extensions/ledger", "bin/extensions/ledger"},
+                  {copy, "./_build/default/lib/blockchain/scripts/extensions/trace", "bin/extensions/trace"},
+                  {copy, "./_build/default/lib/blockchain/scripts/extensions/txn", "bin/extensions/txn"},
+                  {template, "config/vm.args", "{{output_dir}}/releases/{{release_version}}/vm.args"}
+                 ]}
+            ]}
+]}.


### PR DESCRIPTION
Problem to solve: The buildkite build is broken because relx can't find files to copy into the release directory.

Solution: Make profile specific overlay directives.