### PR TITLE
[DO NOT MERGE] Add support for state channel txns

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -37,21 +37,21 @@ doc:
 	$(REBAR) edoc
 
 release:
-	$(REBAR) as prod do release
-
+	$(REBAR) as prod release -n blockchain_etl
 
 start:
 	cp -f .env ./_build/prod/rel/blockchain_etl/
 	./_build/prod/rel/blockchain_etl/bin/blockchain_etl start
 
 stop:
-	-./_build/prod/rel/blockchain_etl/bin/blockchain_etl stop
+	./_build/prod/rel/blockchain_etl/bin/blockchain_etl stop
 
 reset: stop
 	cp -f .env ./_build/prod/rel/blockchain_etl/
 	rm -rf ./_build/prod/rel/blockchain_etl/data/ledger.db
 	rm -rf ./_build/prod/rel/blockchain_etl/log/*
-	_build/prod/bin/psql_migration reset
+	# _build/prod/bin/psql_migration reset
+	./_build/prod/rel/blockchain_etl/bin/extensions/psql_migration reset
 
 resync: stop
 	rm -rf ./_build/prod/rel/blockchain_etl/data/ledger.db

--- a/migrations/1576305004-create-block.sql
+++ b/migrations/1576305004-create-block.sql
@@ -45,7 +45,8 @@ CREATE TYPE transaction_type as ENUM (
         'rewards_v1',
         'token_burn_v1',
         'dc_coinbase_v1',
-        'token_burn_exchange_rate_v1'
+        'token_burn_exchange_rate_v1',
+        'state_channel_open_v1'
 );
 
 CREATE TABLE transactions (

--- a/rebar.config
+++ b/rebar.config
@@ -25,7 +25,7 @@
   {telemetry, "0.4.1"},
   {psql_migration, {git, "https://github.com/helium/psql-migration.git", {branch, "master"}}},
   {clique, {git, "https://github.com/helium/clique.git", {branch, "develop"}}},
-  {blockchain, {git, "https://github.com/helium/blockchain-core.git", {branch, "adt/resync-on-missing-ledger"}}},
+  {blockchain, {git, "https://github.com/helium/blockchain-core.git", {branch, "macpie/ch5377/data-credits-state-channels"}}},
   {envloader, {git, "https://github.com/nuex/envloader.git", {branch, "master"}}}
  ]}.
 

--- a/rebar.config
+++ b/rebar.config
@@ -37,55 +37,41 @@
 
 {shell, [{apps, [lager, envloader, epgsql]}]}.
 
-{relx,
- [
-  {release, {blockchain_etl, "0.1.0"},
-   [
-    blockchain_etl
-   ]},
-
-  {vm_args, "./config/vm.args"},
-  {sys_config, "./config/sys.config"},
-
-  {extended_start_script, true},
-  {include_src, true},
-
-  {overlay,
-   [
-    {copy, "migrations/*.sql", "migrations/"},
-    {copy, "./_build/default/bin/psql_migration", "bin/psql_migration"},
-    {copy, "priv/genesis", "update/genesis"},
-    {copy, "scripts/extensions/genesis", "bin/extensions/genesis"},
-    {copy, "scripts/extensions/info", "bin/extensions/info"},
-    {copy, "./_build/default/lib/blockchain/scripts/extensions/peer", "bin/extensions/peer"},
-    {copy, "./_build/default/lib/blockchain/scripts/extensions/ledger", "bin/extensions/ledger"},
-    {copy, "./_build/default/lib/blockchain/scripts/extensions/trace", "bin/extensions/trace"},
-    {copy, "./_build/default/lib/blockchain/scripts/extensions/txn", "bin/extensions/txn"},
-    {template, "config/vm.args", "{{output_dir}}/releases/{{release_version}}/vm.args"}
-   ]},
-  {extended_start_script_hooks,
-   [
-    {post_start,
-     [
-      {wait_for_process, blockchain_worker}
-     ]}
-   ]},
-  {extended_start_script_extensions,
-   [
-    {genesis, "extensions/genesis"},
-    {info, "extensions/info"},
-    {peer, "extensions/peer"},
-    {ledger, "extensions/ledger"},
-    {trace, "extensions/trace"},
-    {txn, "extensions/txn"}
-   ]}
- ]}.
-
 {profiles,
  [
   {prod,
    [
-    {relx, [{dev_mode, false},
-            {include_erts, true}]}
+    {relx, [
+            {dev_mode, false},
+            {include_erts, true},
+            {release, {blockchain_etl, "0.1.0"}, [blockchain_etl]},
+            {vm_args, "./config/vm.args"},
+            {sys_config, "./config/sys.config"},
+            {extended_start_script, true},
+            {include_src, true},
+            {overlay,
+             [
+              {copy, "migrations/*.sql", "migrations/"},
+              {copy, "priv/genesis", "update/genesis"},
+              {copy, "./_build/default/bin/psql_migration", "bin/extensions/psql_migration"},
+              {copy, "scripts/extensions/genesis", "bin/extensions/genesis"},
+              {copy, "scripts/extensions/info", "bin/extensions/info"},
+              {copy, "./_build/default/lib/blockchain/scripts/extensions/peer", "bin/extensions/peer"},
+              {copy, "./_build/default/lib/blockchain/scripts/extensions/ledger", "bin/extensions/ledger"},
+              {copy, "./_build/default/lib/blockchain/scripts/extensions/trace", "bin/extensions/trace"},
+              {copy, "./_build/default/lib/blockchain/scripts/extensions/txn", "bin/extensions/txn"},
+              {template, "config/vm.args", "{{output_dir}}/releases/{{release_version}}/vm.args"}
+             ]},
+            {extended_start_script_hooks, [{post_start, [{wait_for_process, blockchain_worker}]}]},
+            {extended_start_script_extensions,
+             [
+              {genesis, "extensions/genesis"},
+              {info, "extensions/info"},
+              {peer, "extensions/peer"},
+              {ledger, "extensions/ledger"},
+              {trace, "extensions/trace"},
+              {txn, "extensions/txn"}
+             ]}
+           ]}
    ]}
  ]}.

--- a/src/be_txn.erl
+++ b/src/be_txn.erl
@@ -41,7 +41,10 @@ to_type(blockchain_txn_token_burn_v1) ->
 to_type(blockchain_txn_dc_coinbase_v1) ->
     "dc_coinbase_v1";
 to_type(blockchain_txn_token_burn_exchange_rate_v1) ->
-    "token_burn_exchange_rate_v1".
+    "token_burn_exchange_rate_v1";
+to_type(blockchain_txn_state_channel_open_v1) ->
+    "blockchain_txn_state_channel_open_v1".
+
 
 to_json(T, Ledger) ->
     to_json(blockchain_txn:type(T), T, Ledger).
@@ -201,4 +204,12 @@ to_json(blockchain_txn_dc_coinbase_v1, T, _Ledger) ->
     #{ <<"payee">> => ?BIN_TO_B58(blockchain_txn_dc_coinbase_v1:payee(T)),
        <<"amount">> => blockchain_txn_dc_coinbase_v1:amount(T) };
 to_json(blockchain_txn_token_burn_exchange_rate_v1, T, _Ledger) ->
-    #{<<"rate">> => blockchain_txn_token_burn_exchange_rate_v1:rate(T) }.
+    #{<<"rate">> => blockchain_txn_token_burn_exchange_rate_v1:rate(T) };
+to_json(blockchain_txn_state_channel_open_v1, T, _Ledger) ->
+    #{<<"owner">> => ?BIN_TO_B58(blockchain_txn_state_channel_open_v1:owner(T)),
+      <<"amount">> => blockchain_txn_state_channel_open_v1:amount(T),
+      <<"fee" >> => blockchain_txn_state_channel_open_v1:fee(T),
+      <<"nonce">> => blockchain_txn_state_channel_open_v1:nonce(T),
+      <<"expire_within">> => blockchain_txn_state_channel_open_v1:expire_within(T),
+      <<"id">> => ?BIN_TO_B64(blockchain_txn_state_channel_open_v1:id(T)),
+      <<"signature">> => ?BIN_TO_B64(blockchain_txn_state_channel_open_v1:signature(T)) }.

--- a/src/be_txn_actor.erl
+++ b/src/be_txn_actor.erl
@@ -124,5 +124,7 @@ to_actors(blockchain_txn_token_burn_v1, T) ->
     [{"payer", blockchain_txn_token_burn_v1:payer(T)} ];
 to_actors(blockchain_txn_dc_coinbase_v1, T) ->
     [{"payee", blockchain_txn_dc_coinbase_v1:payee(T)} ];
+to_actors(blockchain_txn_state_channel_open_v1, T) ->
+    [{"owner", blockchain_txn_state_channel_open_v1:owner(T)}];
 to_actors(blockchain_txn_token_burn_exchange_rate_v1, _T) ->
     [].


### PR DESCRIPTION
**This is broken at the moment since it cannot successfully run `psql_migration` reset**

Noteworthy changes:
- Add support for `blockchain_txn_state_channel_open_v1`
- Named prod release
- Move `psql_migration` into extensions instead of yolo bin folder. It wasn't working there either fwiw.

TODO:
- Add support for `blockchain_txn_state_channel_close_v1`
- Fix the damned `psql_migration` reset