### PR TITLE
Remove unused functions for txn_token_burn_v1

### DIFF
--- a/src/be_txn.erl
+++ b/src/be_txn.erl
@@ -191,9 +191,7 @@ to_json(blockchain_txn_rewards_v1, T, _Ledger) ->
        <<"end_epoch">> => blockchain_txn_rewards_v1:end_epoch(T),
        <<"rewards">> => [RewardJson(R) || R <- blockchain_txn_rewards_v1:rewards(T)] };
 to_json(blockchain_txn_token_burn_v1, T, _Ledger) ->
-    #{<<"type">> => blockchain_txn_token_burn_v1:type(T),
-      <<"payer">> => ?BIN_TO_B58(blockchain_txn_token_burn_v1:payer(T)),
-      <<"key">> => ?MAYBE_B58(blockchain_txn_token_burn_v1:key(T)),
+    #{<<"payer">> => ?BIN_TO_B58(blockchain_txn_token_burn_v1:payer(T)),
       <<"amount">> => blockchain_txn_token_burn_v1:amount(T),
       <<"nonce">> => blockchain_txn_token_burn_v1:nonce(T),
       <<"signature">> => ?BIN_TO_B64(blockchain_txn_token_burn_v1:signature(T)) };


### PR DESCRIPTION
The `type` and `key` functions are going to be removed when [core#332](https://github.com/helium/blockchain-core/pull/332) lands.