### PR TITLE
Support tinysshd via tcpserver

### DIFF
--- a/.buildkite/Dockerfile
+++ b/.buildkite/Dockerfile
@@ -3,16 +3,14 @@ FROM ubuntu:18.04
 EXPOSE 22222
 
 RUN apt update
-RUN apt install -y libsodium23 libssl1.1 openssl iproute2 tinysshd
+RUN apt install -y libsodium23 libssl1.1 openssl iproute2 tinysshd ucspi-tcp-ipv6
 RUN apt clean
 
 RUN mkdir -p /root/.ssh
 COPY .buildkite/config/ubuntu.pubkey /root/.ssh/authorized_keys
 RUN chmod 0600 /root/.ssh/authorized_keys
 RUN chmod 0700 /root/.ssh
-COPY .buildkite/config/tinysshd.socket /etc/systemd/system
-COPY .buildkite/config/tinysshd@.service /etc/systemd/system
-RUN systemctl enable tinysshd.socket
+RUN /usr/sbin/tinysshd-makekey /etc/tinyssh/sshkeydir
 COPY .buildkite/config/blockchain_limits.conf /etc/security/limits.d
 
 COPY blockchain-etl*.deb /

--- a/.buildkite/scripts/start.sh
+++ b/.buildkite/scripts/start.sh
@@ -2,6 +2,9 @@
 
 set -euo pipefail
 
+# Start TinySSH listener on port 22222
+/usr/bin/tcpserver -HRDl0 0.0.0.0 22222 /usr/sbin/tinysshd -v /etc/tinyssh/sshkeydir &
+
 /var/helium/blockchain_etl/bin/blockchain_etl escript \
     bin/psql_migration setup
 sleep 1


### PR DESCRIPTION
Problem to solve: We want to run a tinyssh instance on our ETL container and getting systemd to cooperate has proven to be tricky because reasons.

Solution: Use `tcpserver` as our socket listener/accepter