### PR TITLE
Add make profile support.

### DIFF
--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -10,7 +10,7 @@ steps:
   - label: ":debian: build deb"
     commands:
       - "git fetch -t"
-      - "make release"
+      - "make release -e PROFILE=prod"
       - ".buildkite/scripts/make_deb.sh"
     key: "deb"
     artifact_paths: "*.deb"

--- a/Makefile
+++ b/Makefile
@@ -5,6 +5,7 @@ SHORTSHA=`git rev-parse --short HEAD`
 PKG_NAME_VER=${SHORTSHA}
 
 OS_NAME=$(shell uname -s)
+PROFILE := dev
 
 ifeq (${OS_NAME},FreeBSD)
 make="gmake"
@@ -37,25 +38,25 @@ doc:
 	$(REBAR) edoc
 
 release:
-	$(REBAR) as prod do release
+	$(REBAR) as $(PROFILE) do release
 
 
 start:
-	cp -f .env ./_build/prod/rel/blockchain_etl/
-	./_build/prod/rel/blockchain_etl/bin/blockchain_etl start
+	cp -f .env ./_build/$(PROFILE)/rel/blockchain_etl/
+	./_build/$(PROFILE)/rel/blockchain_etl/bin/blockchain_etl start
 
 stop:
-	-./_build/prod/rel/blockchain_etl/bin/blockchain_etl stop
+	-./_build/$(PROFILE)/rel/blockchain_etl/bin/blockchain_etl stop
 
 reset: stop
-	cp -f .env ./_build/prod/rel/blockchain_etl/
-	rm -rf ./_build/prod/rel/blockchain_etl/data/ledger.db
-	rm -rf ./_build/prod/rel/blockchain_etl/log/*
-	_build/prod/rel/blockchain_etl/bin/blockchain_etl migrations reset
+	cp -f .env ./_build/$(PROFILE)/rel/blockchain_etl/
+	rm -rf ./_build/$(PROFILE)/rel/blockchain_etl/data/ledger.db
+	rm -rf ./_build/$(PROFILE)/rel/blockchain_etl/log/*
+	_build/$(PROFILE)/rel/blockchain_etl/bin/blockchain_etl migrations reset
 
 resync: stop
-	rm -rf ./_build/prod/rel/blockchain_etl/data/ledger.db
-	rm -rf ./_build/prod/rel/blockchain_etl/log/*
+	rm -rf ./_build/$(PROFILE)/rel/blockchain_etl/data/ledger.db
+	rm -rf ./_build/$(PROFILE)/rel/blockchain_etl/log/*
 
 console:
-	./_build/prod/rel/blockchain_etl/bin/blockchain_etl remote_console
+	./_build/$(PROFILE)/rel/blockchain_etl/bin/blockchain_etl remote_console

--- a/config/sys.config
+++ b/config/sys.config
@@ -1,10 +1,5 @@
 %% -*- erlang -*-
 [
- {kernel,
-  [
-   %% force distributed erlang to only run on localhost
-   {inet_dist_use_interface, {127,0,0,1}}
-  ]},
  {pg_types, [{json_config, {jsone, [], [{keys, atom}]}}]},
  {blockchain_etl,
   [

--- a/rebar.config
+++ b/rebar.config
@@ -78,6 +78,7 @@
       {dev_mode, true},
       {overlay,
        [
+        {copy, "config/sys.config", "config/sys.config"},
         {copy, "migrations/*.sql", "migrations/"},
         {copy, "priv/genesis", "update/genesis"},
         {copy, "scripts/extensions/genesis", "bin/extensions/genesis"},
@@ -99,6 +100,7 @@
       {include_erts, true},
       {overlay,
        [
+        {copy, "config/sys.config", "config/sys.config"},
         {copy, "migrations/*.sql", "migrations/"},
         {copy, "priv/genesis", "update/genesis"},
         {copy, "scripts/extensions/genesis", "bin/extensions/genesis"},
@@ -121,6 +123,7 @@
       {sys_config, "./config/local.config"},
       {overlay,
        [
+        {copy, "config/sys.config", "config/sys.config"},
         {copy, "migrations/*.sql", "migrations/"},
         {copy, "priv/genesis", "update/genesis"},
         {copy, "scripts/extensions/genesis", "bin/extensions/genesis"},
@@ -140,6 +143,7 @@
     {dev_mode, true},
     {overlay,
      [
+      {copy, "config/sys.config", "config/sys.config"},
       {copy, "migrations/*.sql", "migrations/"},
       {copy, "priv/genesis", "update/genesis"},
       {copy, "scripts/extensions/genesis", "bin/extensions/genesis"},


### PR DESCRIPTION
Set dev as default profile. This will break existing prod based
installs but it looks like they were broken for makefile support anyway

Buildkite will set PROFILE to prod for the debian package build to get
the same effect we were having before