### PR TITLE
Make .env pluggable in sys.config

### DIFF
--- a/config/prod.config
+++ b/config/prod.config
@@ -1,6 +1,10 @@
 %% -*- erlang -*-
 [
  "config/sys.config",
+ {blockchain_etl,
+ [
+  {db_env, "/var/data/blockchain_etl/.env"}
+ ]},
  {lager,
   [
    {log_root, "/var/data/log/blockchain_etl"}

--- a/config/sys.config
+++ b/config/sys.config
@@ -4,6 +4,7 @@
  {blockchain_etl,
   [
    {port, 8080},
+   {db_env, ".env"},
    {db_pool,
     [
      %% We keep the pool small since all blocks are handled in a

--- a/src/be_sup.erl
+++ b/src/be_sup.erl
@@ -75,8 +75,8 @@ init([]) ->
                       {update_dir, "update"},
                       {base_dir, BaseDir}
                      ],
-
-    {ok, DBOpts} = psql_migration:connection_opts([]),
+    {ok, DBEnv} = application:get_env(blockchain_etl, db_env),
+    {ok, DBOpts} = psql_migration:connection_opts([{env, DBEnv}]),
     {ok, PoolArgs} = application:get_env(blockchain_etl, db_pool),
     {ok, DBHandlers} = application:get_env(blockchain_etl, db_handlers),
 


### PR DESCRIPTION
The changes in the build scripts pull in an empty .env which overrides the target installation directory. This changes the prod release to make the .env configurable and sets it to `/var/data/blockchain_etl/.env` for the prod release