### PR TITLE
Add first_block to gateways

### DIFF
--- a/migrations/1584651322-gateway_first_block.sql
+++ b/migrations/1584651322-gateway_first_block.sql
@@ -1,0 +1,42 @@
+-- migrations/1584651322-gateway_first_block.sql
+-- :up
+
+alter table gateways add column first_block bigint references blocks(height);
+
+-- update all gateway rows with the first block that account was seen
+-- in
+update gateways set first_block=subquery.block
+       from (select min(block) as block, address
+            from gateways group by address) as subquery
+where gateways.address=subquery.address;
+
+alter table gateways alter column first_block set not null;
+
+-- recreate materialized view
+drop materialized view gateway_ledger;
+create materialized view gateway_ledger as
+       select * from gateways
+       where (block, address) in
+             (select max(block) as block, address from gateways group by address);
+
+-- recreate unique index
+create unique index gateway_ledger_gateway_idx on gateway_ledger(address);
+-- Add an index that allows ordering the ledger for paging purposes
+create index gateway_ledger_first_block_idx on gateway_ledger(first_block);
+
+-- :down
+
+-- Drop the materialized view so it doesn't depend on first_block
+drop materialized view gateway_ledger;
+
+-- remove the column from gateways
+alter table gateways drop column first_block;
+
+-- recreate materialized view
+create materialized view gateway_ledger as
+       select * from gateways
+       where (block, address) in
+             (select max(block) as block, address from gateways group by address);
+
+-- recreate unique index
+create unique index gateway_ledger_gateway_idx on gateway_ledger(address);

--- a/src/be_gateway.erl
+++ b/src/be_gateway.erl
@@ -32,7 +32,7 @@
 prepare_conn(Conn) ->
     {ok, _} =
         epgsql:parse(Conn, ?Q_INSERT_GATEWAY,
-                     "insert into gateways (block, address, owner, location, alpha, beta, delta, score, last_poc_challenge, last_poc_onion_key_hash, witnesses) values ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11);", []),
+                     "insert into gateways (first_block, block, address, owner, location, alpha, beta, delta, score, last_poc_challenge, last_poc_onion_key_hash, witnesses) select (select coalesce((select first_block from accounts where address=$3 limit 1), $1) as first_block), $1 as block, $2 as address, $3 as owner, $4 as location, $5 as alpha, $6 as beta, $7 as delta, $8 as score, $9 as last_poc_challenge, $10 as last_poc_onion_key_hash, $11 as witnesses;", []),
 
     ok.
 


### PR DESCRIPTION
This adds first_block to the gateways table and exposes it in the gateway_ledger. This will allow ordering of the ledger to remain stable (in combination with the gateway address)