### PR TITLE
Empty .env file

### DIFF
--- a/config/.env
+++ b/config/.env
@@ -1,1 +1,1 @@
-DATABASE_URL=postgresql://localhost/blockchain
+


### PR DESCRIPTION
This file gets copied to the release directory on production builds and is always loaded by `psql_migration`. The current `make run` command overwrites this file if the build is on a local machine but this doesn't work for a clean checkout.