### PR TITLE
Rebuild first_blocks

### DIFF
--- a/migrations/1586300385-rebuild_first_blocks.sql
+++ b/migrations/1586300385-rebuild_first_blocks.sql
@@ -1,0 +1,20 @@
+-- migrations/1586300385-rebuild_first_blocks.sql
+-- :up
+
+-- update all gateway rows with the first block that gateway was seen
+-- in. This will take a long time
+update gateways set first_block=subquery.block
+       from (select min(block) as block, address
+            from gateways group by address) as subquery
+where gateways.address=subquery.address;
+
+-- update all account rows with the first block that account was seen
+-- in. This will takea long time too!
+update accounts set first_block=subquery.block
+       from (select min(block) as block, address
+            from accounts group by address) as subquery
+where accounts.address=subquery.address;
+
+-- :down
+
+-- No down migration possible or required

--- a/src/be_account.erl
+++ b/src/be_account.erl
@@ -42,7 +42,18 @@
 prepare_conn(Conn) ->
     {ok, _} =
         epgsql:parse(Conn, ?Q_INSERT_ACCOUNT,
-                     "insert into accounts (first_block, block, timestamp, address, dc_balance, dc_nonce, security_balance, security_nonce, balance, nonce) select (select coalesce((select first_block from accounts where address=$3 limit 1), $1) as first_block), $1 as block, $2 as timestamp, $3 as address, $4 as dc_balance, $5 as dc_nonce, $6 as security_balance, $7 as security_nonce, $8 as balance, $9 as nonce", []),
+                     ["insert into accounts (first_block, block, timestamp, address, dc_balance, dc_nonce, security_balance, security_nonce, balance, nonce) select ",
+                      "(select coalesce((select min(block) from accounts where address=$3), $1) as first_block), ",
+                      "$1 as block, ",
+                      "$2 as timestamp, ",
+                      "$3 as address, ",
+                      "$4 as dc_balance, ",
+                      "$5 as dc_nonce, ",
+                      "$6 as security_balance, ",
+                      "$7 as security_nonce, ",
+                      "$8 as balance, ",
+                      "$9 as nonce"],
+                     []),
 
     ok.
 

--- a/src/be_gateway.erl
+++ b/src/be_gateway.erl
@@ -32,7 +32,20 @@
 prepare_conn(Conn) ->
     {ok, _} =
         epgsql:parse(Conn, ?Q_INSERT_GATEWAY,
-                     "insert into gateways (first_block, block, address, owner, location, alpha, beta, delta, score, last_poc_challenge, last_poc_onion_key_hash, witnesses) select (select coalesce((select first_block from accounts where address=$3 limit 1), $1) as first_block), $1 as block, $2 as address, $3 as owner, $4 as location, $5 as alpha, $6 as beta, $7 as delta, $8 as score, $9 as last_poc_challenge, $10 as last_poc_onion_key_hash, $11 as witnesses;", []),
+                     ["insert into gateways (first_block, block, address, owner, location, alpha, beta, delta, score, last_poc_challenge, last_poc_onion_key_hash, witnesses) select ",
+                      "(select coalesce((select min(block) from gateways where address=$2), $1) as first_block), ",
+                      "$1 as block, ",
+                      "$2 as address, ",
+                      "$3 as owner, ",
+                      "$4 as location, ",
+                      "$5 as alpha, ",
+                      "$6 as beta, ",
+                      "$7 as delta, ",
+                      "$8 as score, ",
+                      "$9 as last_poc_challenge, ",
+                      "$10 as last_poc_onion_key_hash, ",
+                      "$11 as witnesses;"],
+                      []),
 
     ok.
 


### PR DESCRIPTION
Rebuilds the first_block values for all accounts and gateway records
since the insertion logic was doing it wrong.

The migration resets all values to the correct one while the run-time
insertion statements are fixed to use the correct block