### PR TITLE
Fix payment_v2 filter for payer

### DIFF
--- a/migrations/1587175755-fix_txn_filter_payment.sql
+++ b/migrations/1587175755-fix_txn_filter_payment.sql
@@ -1,0 +1,40 @@
+create or replace function txn_filter_actor_activity(actor text, type transaction_type, fields jsonb) returns jsonb as $$
+begin
+    case
+        when type = 'rewards_v1' then
+            return jsonb_set(fields, '{rewards}', (select jsonb_agg(x) from jsonb_to_recordset(fields#>'{rewards}') as x(account text, amount bigint, type text, gateway text) where account = actor or gateway = actor));
+        when type = 'payment_v2' then
+            if fields->>'payer' = actor then
+                return fields;
+            else
+                return jsonb_set(fields, '{payments}', (select jsonb_agg(x) from jsonb_to_recordset(fields#>'{payments}') as x(payee text, amount bigint) where payee = actor));
+            end if;
+        when type = 'consensus_group_v1' then
+           return fields - 'proof';
+        else
+            return fields;
+    end case;
+end; $$
+language plpgsql;
+
+-- :down
+
+-- Put back the broken payer filter
+create or replace function txn_filter_actor_activity(actor text, type transaction_type, fields jsonb) returns jsonb as $$
+begin
+    case
+        when type = 'rewards_v1' then
+            return jsonb_set(fields, '{rewards}', (select jsonb_agg(x) from jsonb_to_recordset(fields#>'{rewards}') as x(account text, amount bigint, type text, gateway text) where account = actor or gateway = actor));
+        when type = 'payment_v2' then
+            if (fields#>'{payer}')::text = actor then
+                return fields;
+            else
+                return jsonb_set(fields, '{payments}', (select jsonb_agg(x) from jsonb_to_recordset(fields#>'{payments}') as x(payee text, amount bigint) where payee = actor));
+            end if;
+        when type = 'consensus_group_v1' then
+           return fields - 'proof';
+        else
+            return fields;
+    end case;
+end; $$
+language plpgsql;


### PR DESCRIPTION
The payment_v2 transaction actor filter would take the wrong branch because we were  using the wrong json operator to extract the payer field. 

This migration fixes that oversight