### PR TITLE
Add erts to dev release profile

### DIFF
--- a/rebar.config
+++ b/rebar.config
@@ -90,7 +90,8 @@
      [
       {sys_config, "./config/dev.config"},
       {dev_mode, true},
-      {include_erts, false}
+      %% include erts to make migrations script work
+      {include_erts, true}
      ]}
    ]},
   {prod,


### PR DESCRIPTION
This fixes the migrations script which does not knwo where the system
erlang is installed.