### PR TITLE
Move enum alters to individual migrations

### DIFF
--- a/migrations/1588975207-state_channel_open.sql
+++ b/migrations/1588975207-state_channel_open.sql
@@ -1,0 +1,8 @@
+-- migrations/1588975207-state_channel.sql
+-- :up
+-- Up migration
+ALTER TYPE transaction_type ADD VALUE 'state_channel_open_v1';
+
+-- :down
+-- Down migration
+-- There's nothing really to do here sadly

--- a/migrations/1588975208-state_channel_close.sql
+++ b/migrations/1588975208-state_channel_close.sql
@@ -1,7 +1,6 @@
 -- migrations/1588975207-state_channel.sql
 -- :up
 -- Up migration
-ALTER TYPE transaction_type ADD VALUE 'state_channel_open_v1';
 ALTER TYPE transaction_type ADD VALUE 'state_channel_close_v1';
 
 -- :down

--- a/migrations/1588975221-state_channel_role_open.sql
+++ b/migrations/1588975221-state_channel_role_open.sql
@@ -2,7 +2,6 @@
 -- :up
 -- Up migration
 ALTER TYPE transaction_actor_role ADD VALUE 'sc_opener';
-ALTER TYPE transaction_actor_role ADD VALUE 'sc_closer';
 
 -- :down
 -- Down migration

--- a/migrations/1588975222-state_channel_role_close.sql
+++ b/migrations/1588975222-state_channel_role_close.sql
@@ -1,0 +1,8 @@
+-- migrations/1588975221-state_channel_role.sql
+-- :up
+-- Up migration
+ALTER TYPE transaction_actor_role ADD VALUE 'sc_closer';
+
+-- :down
+-- Down migration
+-- Nothing to do here.


### PR DESCRIPTION
psql migrations don't like multiple alter types in the same migration. Split them up into individual migrations.. Sorry :-/