### PR TITLE
Add a migrations make target

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -40,6 +40,8 @@ doc:
 release:
 	$(REBAR) as $(PROFILE) do release
 
+migrations: stop
+	./_build/$(PROFILE)/rel/blockchain_etl/bin/blockchain_etl migrations run
 
 start:
 	cp -f .env ./_build/$(PROFILE)/rel/blockchain_etl/


### PR DESCRIPTION
This makes it easier to run migrations as a make target

`make migrations` will stop a running ETL application and run available database migrations. 

*Note* that you will need to `make start` to restart the application once migrations are complete