### PR TITLE
Account inventory

### DIFF
--- a/migrations/1590689602-gateway_inventory.sql
+++ b/migrations/1590689602-gateway_inventory.sql
@@ -51,7 +51,8 @@ BEGIN
        last_poc_challenge = EXCLUDED.last_poc_challenge,
        last_poc_onion_key_hash = EXCLUDED.last_poc_onion_key_hash,
        witnesses = EXCLUDED.witnesses,
-       last_block = EXCLUDED.block;
+       last_block = EXCLUDED.last_block;
+  RETURN NEW;
 END;
 $$ LANGUAGE plpgsql;
 

--- a/migrations/1591133143-account_inventory.sql
+++ b/migrations/1591133143-account_inventory.sql
@@ -1,0 +1,91 @@
+-- migrations/1591133143-account_inventory.sql
+-- :up
+
+alter table accounts drop column timestamp;
+
+create table acount_inventory (
+       address TEXT NOT NULL,
+
+       balance BIGINT NOT NULL,
+       nonce BIGINT NOT NULL,
+
+       dc_balance BIGINT NOT NULL,
+       dc_nonce BIGINT NOT NULL,
+
+       security_balance BIGINT NOT NULL,
+       security_nonce BIGINT NOT NULL,
+
+       first_block BIGINT references blocks(height) on delete set NULL,
+       last_block BIGINT references blocks(height) on delete set NULL,
+
+       PRIMARY KEY (address)
+);
+
+create index account_inventory_first_block on account_inventory(first_block);
+
+insert into account_inventory
+       select a.address,
+              a.balance,
+              a.nonce,
+              a.dc_balance,
+              a.dc_nonce,
+              a.security_balance,
+              a.security_nonce,
+              aa.first_block,
+              aa.last_block
+        from
+             (select max(block) as last_block, min(block) as first_block, address from accounts group by address) aa
+              inner join accounts a on (a.block, a.address) = (aa.last_block, aa.address);
+
+CREATE OR REPLACE FUNCTION account_inventory_update()
+ RETURNS TRIGGER AS $$
+ BEGIN
+   insert into account_inventory
+          (address,
+          balance, nonce,
+          dc_balance, dc_nonce,
+          security_balance, security_nonce,
+          first_block, last_block)
+   VALUES
+         (NEW.address,
+         NEW.balance, NEW.nonce,
+         NEW.dc_balance, NEW.dc_nonce,
+         NEW.security_balance, NEW.security_nonce,
+         NEW.block, NEW.block
+         )
+   ON CONFLICT (address) DO UPDATE SET
+        balance = EXCLUDED.balance,
+        nonce = EXCLUDED.nonce,
+        dc_balance = EXCLUDED.dc_balance,
+        dc_nonce = EXCLUDED.dc_nonce,
+        security_balance = EXCLUDED.security_balance,
+        security_nonce = EXCLUDED.security_nonce,
+        last_block = EXCLUDED.block;
+ END;
+ $$ LANGUAGE plpgsql;
+
+create trigger account_insert
+       after insert on accounts
+       for each row
+       execute procedure account_inventory_update();
+
+ drop materialized view account_ledger;
+
+
+-- :down
+
+-- Create account ledger with first_block
+create materialized view account_ledger as
+    select aa.first_block, a.*  from
+        (select max(block) as last_block, min(block) as first_block, address from accounts group by address) aa
+        inner join accounts a on (a.block, a.address) = (aa.last_block, aa.address);
+
+-- recreate unique index
+create unique index account_ledger_address_idx on account_ledger(address);
+-- Add an index that allows ordering the ledger for paging purposes
+create index account_ledger_first_block_idx on account_ledger(first_block);
+
+-- Destroy the new stuff
+drop trigger account_insert on accounts;
+drop function account_inventory_update;
+drop table account_inventory;

--- a/migrations/1591133143-account_inventory.sql
+++ b/migrations/1591133143-account_inventory.sql
@@ -1,9 +1,7 @@
 -- migrations/1591133143-account_inventory.sql
 -- :up
 
-alter table accounts drop column timestamp;
-
-create table acount_inventory (
+create table account_inventory (
        address TEXT NOT NULL,
 
        balance BIGINT NOT NULL,
@@ -60,7 +58,8 @@ CREATE OR REPLACE FUNCTION account_inventory_update()
         dc_nonce = EXCLUDED.dc_nonce,
         security_balance = EXCLUDED.security_balance,
         security_nonce = EXCLUDED.security_nonce,
-        last_block = EXCLUDED.block;
+        last_block = EXCLUDED.last_block;
+  RETURN NEW;
  END;
  $$ LANGUAGE plpgsql;
 
@@ -69,7 +68,8 @@ create trigger account_insert
        for each row
        execute procedure account_inventory_update();
 
- drop materialized view account_ledger;
+drop materialized view account_ledger;
+alter table accounts drop column timestamp;
 
 
 -- :down

--- a/migrations/1591138658-state_channel_accounts.sql
+++ b/migrations/1591138658-state_channel_accounts.sql
@@ -1,0 +1,11 @@
+-- migrations/1591138658-state_channel_accounts.sql
+-- :up
+
+insert into transaction_actors
+    (select actor, 'payer' as actor_role, transaction_hash, block from transaction_actors where actor_role = 'sc_opener');
+
+insert into transaction_actors
+    (select actor, 'payee' as actor_role, transaction_hash, block from transaction_actors where actor_role = 'sc_closer');
+
+-- :down
+-- We're not going to down migrate some extra actors

--- a/src/be_db_geocoder.erl
+++ b/src/be_db_geocoder.erl
@@ -101,11 +101,16 @@ handle_info({hackney_response, Ref,  {error, Error}}, State=#state{}) ->
                 end, Ref, State);
 handle_info({hackney_response, Ref, Bin}, State=#state{})  when is_binary(Bin) ->
     take_request(fun(Loc) ->
-                         case parse_geocode_results(jsone:decode(Bin)) of
-                             {ok, Results} ->
-                                 {ok, _} = store_geocode_result(Loc, Results);
-                             {error, Error} ->
-                                 lager:info("Failed to get geocode for ~p: ~p", [Loc, Error])
+                         try
+                             case parse_geocode_results(jsone:decode(Bin)) of
+                                 {ok, Results} ->
+                                     {ok, _} = store_geocode_result(Loc, Results);
+                                 {error, Error} ->
+                                     lager:info("Failed to get geocode for ~p: ~p", [Loc, Error])
+                             end
+                         catch
+                             What:Why ->
+                                 lager:info("Failed to get geocode for ~p: ~p", [Loc, {What, Why}])
                          end
                  end, Ref, State);
 


### PR DESCRIPTION
This switches from a materialized view for account to an
account_inventory which is updated on a trigger with newly inserted
rows for accounts.

This should make ledger recalculation time go away and, more importantly make account inventory updates more synchronized with the block that affects any account