### PR TITLE
relax gateway recent challenge check

### DIFF
--- a/src/be_db_gateway_status.erl
+++ b/src/be_db_gateway_status.erl
@@ -227,7 +227,7 @@ peer_recent_challenger(Address, Ledger) ->
             case blockchain_ledger_gateway_v2:last_poc_challenge(GWInfo) of
                 undefined ->
                     false;
-                LastChallenge when LastChallenge >= (Height - PoCInterval)->
+                LastChallenge when LastChallenge >= (Height - (2 * PoCInterval)) ->
                     true;
                 _ ->
                     false


### PR DESCRIPTION
Relaxes the recent challenge check for hotspot status twice the poc
interval instead of just once.