### PR TITLE
Add oracle_inventory

### DIFF
--- a/migrations/1593389882-oracle_inventory.sql
+++ b/migrations/1593389882-oracle_inventory.sql
@@ -1,0 +1,12 @@
+-- migrations/1593389882-oracle_inventory.sql
+-- :up
+
+create table oracle_inventory (
+       address TEXT NOT NULL,
+
+       PRIMARY KEY (address)
+);
+
+-- :down
+
+drop table oracle_inventory;


### PR DESCRIPTION
Adds an oracle_inventory table to be able to query the oracle public keys without having to decode base64 encoded values from the vars_inventory table