### PR TITLE
Break out gateway_status fields

### DIFF
--- a/migrations/1594155785-gateway_status_parts.sql
+++ b/migrations/1594155785-gateway_status_parts.sql
@@ -1,0 +1,12 @@
+-- migrations/1594155785-gateway_status_parts.sql
+-- :up
+
+alter table gateway_status
+      add column poc_interval BIGINT,
+      add column last_challenge BIGINT;
+
+-- :down
+
+alter table gateway_status
+      drop column poc_interval,
+      drop column last_challenge;


### PR DESCRIPTION
This leaves the online derived column intact for now with plans for its future removal since the front ends can derive the online status from the stored values