### PR TITLE
Fix duplicate transactions from router

### DIFF
--- a/src/be_db_block.erl
+++ b/src/be_db_block.erl
@@ -50,8 +50,10 @@ prepare_conn(Conn) ->
                      []),
     {ok, S3} =
         epgsql:parse(Conn, ?S_INSERT_TXN,
-                     "insert into transactions (block, time, hash, type, fields) values ($1, $2, $3, $4, $5)",
-                     []),
+                     ["insert into transactions (block, time, hash, type, fields) values ($1, $2, $3, $4, $5) ",
+                      "on conflict do nothing"
+                      ], []),
+
 
     #{
       ?S_BLOCK_HEIGHT => S0,
@@ -115,7 +117,9 @@ q_insert_block(Hash, Block, Ledger, Queries, State=#state{base_secs=BaseSecs}) -
               ?MAYBE_B64(blockchain_block_v1:snapshot_hash(Block))
              ],
     [{?S_INSERT_BLOCK, Params}
-     | q_insert_signatures(Block, q_insert_transactions(Block, Queries, Ledger, State), State)].
+     | q_insert_signatures(Block,
+                           q_insert_transactions(Block, Queries, Ledger, State),
+                           State)].
 
 q_insert_signatures(Block, Queries, #state{}) ->
     Height = blockchain_block_v1:height(Block),

--- a/src/be_db_txn_actor.erl
+++ b/src/be_db_txn_actor.erl
@@ -25,8 +25,9 @@ prepare_conn(Conn) ->
     {ok, S1} =
         epgsql:parse(Conn, ?S_INSERT_ACTOR,
                      ["insert into transaction_actors (block, actor, actor_role, transaction_hash) ",
-                      "values ($1, $2, $3, $4)"],
-                     []),
+                      "values ($1, $2, $3, $4) ",
+                      "on conflict do nothing"
+                     ], []),
 
     #{
       ?S_INSERT_ACTOR => S1


### PR DESCRIPTION
We do this by ignoring conflicts on insert for transsactions and actors.
This will have some odd side effects like the block txn count being of
but these errors should be exceedling rare.