### PR TITLE
Add listen_addrs to gateway_status

### DIFF
--- a/migrations/1609078980-gateway_listen_addrs.sql
+++ b/migrations/1609078980-gateway_listen_addrs.sql
@@ -1,0 +1,10 @@
+-- migrations/1609078980-gateway_listen_addrs.sql
+-- :up
+
+alter table gateway_status 
+add column listen_addrs jsonb;
+
+-- :down
+
+alter table gateway_status 
+drop column listen_addrs;


### PR DESCRIPTION
Adds a jsonb `listen_addrs` column which is updated as part of the gateway status update cycle