### PR TITLE
Adds packet tracking

### DIFF
--- a/config/sys.config
+++ b/config/sys.config
@@ -30,7 +30,8 @@
        be_db_oracle_price,
        be_db_vars,
        be_db_stats,
-       be_db_reward
+       be_db_reward,
+       be_db_packet
       ]}
     ]}
   ]},

--- a/migrations/1609338698-packets.sql
+++ b/migrations/1609338698-packets.sql
@@ -1,0 +1,46 @@
+-- migrations/1609338698-packets.sql
+-- :up
+
+create table packets (
+       block bigint not null references blocks(height) on delete cascade,
+       transaction_hash text not null references transactions(hash),
+       time bigint not null,
+       gateway text not null,
+       num_packets bigint not null,
+       num_dcs bigint not null,
+
+       primary key(block, transaction_hash, gateway)
+);
+
+
+create type packet_entry as (client TEXT, type TEXT, num_packets bigint, num_dcs bigint);
+create or replace function insert_packets() returns void as $$
+declare
+    txn RECORD;
+begin
+    for txn in
+        select *
+        from transactions where type = 'state_channel_close_v1'
+        order by block asc
+    loop
+        insert into packets (block, transaction_hash, time, gateway, num_packets, num_dcs)
+        select 
+            txn.block, txn.hash, txn.time, client as gateway, 
+            sum(num_packets)::bigint as num_packets, 
+            sum(num_dcs)::bigint as num_dcs
+        from jsonb_populate_recordset(null::packet_entry, txn.fields#>'{state_channel, summaries}')
+        group by client;
+    end loop;
+end; $$
+language plpgsql;
+
+select insert_packets();
+
+create index packets_block_idx on packets(block);
+create index packets_gateway_idx on packets(gateway);
+
+-- :down
+
+drop function insert_packets;
+drop table packets;
+drop type packet_entry;

--- a/src/be_db_follower.erl
+++ b/src/be_db_follower.erl
@@ -27,7 +27,8 @@
          be_db_oracle_price,
          be_db_vars,
          be_db_stats,
-         be_db_reward
+         be_db_reward,
+         be_db_packet
          ]).
 
 -record(state,

--- a/src/be_db_packet.erl
+++ b/src/be_db_packet.erl
@@ -1,0 +1,100 @@
+-module(be_db_packet).
+
+-include("be_db_follower.hrl").
+-include("be_db_worker.hrl").
+
+-export([prepare_conn/1]).
+%% be_block_handler
+-export([init/1, load_block/6]).
+
+-behavior(be_db_worker).
+-behavior(be_db_follower).
+
+-record(state, {}).
+
+-define(S_INSERT_PACKET, "insert_packet").
+
+%%
+%% be_db_worker
+%%
+
+prepare_conn(Conn) ->
+    {ok, S1} = epgsql:parse(
+        Conn,
+        ?S_INSERT_PACKET,
+        [
+            "insert into packets (block, transaction_hash, time, gateway, num_packets, num_dcs) ",
+            "values ($1, $2, $3, $4, $5, $6) "
+        ],
+        []
+    ),
+    #{?S_INSERT_PACKET => S1}.
+
+%%
+%% be_block_handler
+%%
+
+init(_) ->
+    {ok, #state{}}.
+
+load_block(Conn, _Hash, Block, _Sync, _Ledger, State = #state{}) ->
+    BlockHeight = blockchain_block_v1:height(Block),
+    BlockTime = blockchain_block_v1:time(Block),
+    Txns = lists:filter(
+        fun(T) ->
+            blockchain_txn:type(T) == blockchain_txn_state_channel_close_v1
+        end,
+        blockchain_block_v1:transactions(Block)
+    ),
+    Queries = lists:foldl(
+        fun(T, TAcc) ->
+            TxnHash = ?BIN_TO_B64(blockchain_txn:hash(T)),
+            PacketMap = collect_packets(blockchain_state_channel_v1:summaries(blockchain_txn_state_channel_close_v1:state_channel(T)), #{}),
+            lists:foldl(
+                fun(Entry, RAcc) ->
+                    q_insert_packet(
+                        BlockHeight,
+                        TxnHash,
+                        BlockTime,
+                        Entry,
+                        RAcc
+                    )
+                end,
+                TAcc,
+                maps:to_list(PacketMap)
+            )
+        end,
+        [],
+        Txns
+    ),
+    ok = ?BATCH_QUERY(Conn, Queries),
+    {ok, State}.
+
+-type packet_map() :: #{
+    Gateway :: libp2p_crypto:pubkey_bin() => {NumPackets :: pos_integer(), NumDCs :: pos_integer()}
+}.
+
+-spec collect_packets(blockchain_state_channel_close_v1:summaries(), packet_map()) -> packet_map().
+collect_packets([], PacketMap) ->
+    PacketMap;
+collect_packets([Summary | Rest], Map) ->
+    Key = blockchain_state_channel_summary_v1:client_pubkeybin(Summary),
+    {NumPackets, NumDCs} = maps:get(Key, Map, {0, 0}),
+    collect_packets(Rest, 
+        maps:put(Key, 
+                {
+                    NumPackets + blockchain_state_channel_summary_v1:num_packets(Summary), 
+                    NumDCs + blockchain_state_channel_summary_v1:num_dcs(Summary)
+                }, 
+                Map)).
+
+q_insert_packet(BlockHeight, TxnHash, BlockTime, {Gateway, {NumPackets, NumDCs}}, Queries) ->
+    Params = [
+        BlockHeight,
+        TxnHash,
+        BlockTime,
+        ?BIN_TO_B58(Gateway),
+        NumPackets,
+        NumDCs
+    ],
+    [{?S_INSERT_PACKET, Params} | Queries].


### PR DESCRIPTION
This extracts the packet/dc counts from state_channel_close transactions (similar to how rewards are extracted from rewards transactions) to allow for queries around data transfers. 