### PR TITLE
Adds jsonb_merge_agg aggregator

### DIFF
--- a/migrations/1609356128-jsonb_merge_agg.sql
+++ b/migrations/1609356128-jsonb_merge_agg.sql
@@ -1,0 +1,14 @@
+-- migrations/1609356128-jsonb_merge_agg.sql
+-- :up
+
+create aggregate jsonb_merge_agg(jsonb)
+(
+    sfunc = jsonb_concat,
+    stype = jsonb,
+    initcond = '{}'
+);
+
+
+-- :down
+
+drop aggregate if exists jsonb_merge_agg(jsonb);


### PR DESCRIPTION
Adds an aggregator to union multiple jsonb maps together. This is used, for example, to merge witness maps 