### PR TITLE
Fix up oui_inventory

### DIFF
--- a/migrations/1612480010-ouis.sql
+++ b/migrations/1612480010-ouis.sql
@@ -100,7 +100,7 @@ on conflict do nothing;
 with data as (
     select
         block,
-        fields->>'owner'::text as owner,
+        (select owner from oui_inventory where oui = (fields->>'oui')::numeric) as owner,
         (fields->>'oui')::numeric as oui,
         (select coalesce(array_agg(a)::text[], array[]::text[]) from jsonb_array_elements_text(fields#>'{actions, addresses}') as a) as addresses,
         (select array[]::int[][]) as subnets

--- a/src/be_db_backfill.erl
+++ b/src/be_db_backfill.erl
@@ -149,17 +149,24 @@ oui_subnets() ->
     lists:foreach(
         fun(Route) ->
             Oui = blockchain_ledger_routing_v1:oui(Route),
+            Owner = ?BIN_TO_B58(blockchain_ledger_routing_v1:owner(Route)),
             Nonce = blockchain_ledger_routing_v1:nonce(Route),
             Subnets = [
                 be_db_oui:subnet_to_list(S)
              || S <- blockchain_ledger_routing_v1:subnets(Route)
             ],
+            Addresses = [?BIN_TO_B58(A) || A <- blockchain_ledger_routing_v1:addresses(Route)],
             {ok, _} =
-                ?EQUERY("update oui_inventory set subnets = $2, nonce = $3 where oui = $1", [
-                    Oui,
-                    Subnets,
-                    Nonce
-                ])
+                ?EQUERY(
+                    "update oui_inventory set subnets = $2, nonce = $3, owner = $4, addresses = $5 where oui = $1",
+                    [
+                        Oui,
+                        Subnets,
+                        Nonce,
+                        Owner,
+                        Addresses
+                    ]
+                )
         end,
         Routes
     ),


### PR DESCRIPTION
oui inventory was representing incorrect routers as owners since routing_v1 transactions can have the “owner” be any of the currently valid router addresses.

The backfill fixes up the owner address for ouis, and adds the router addresses back in.

The fixed up migration will help newly migrated folks to get the same effect