### PR TITLE
Use .env.dev by default, and allow PROFILE ENV var

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -5,7 +5,7 @@ SHORTSHA=`git rev-parse --short HEAD`
 PKG_NAME_VER=${SHORTSHA}
 
 OS_NAME=$(shell uname -s)
-PROFILE := dev
+PROFILE ?= dev
 
 ifeq (${OS_NAME},FreeBSD)
 make="gmake"

--- a/README.md
+++ b/README.md
@@ -11,11 +11,11 @@ listening for new block events.
 ## Developer Usage
 
 * Clone this repository
-* Create `.env` file by copying `.env.template` and editing it to
+* Create `.env.dev` file by copying `.env.template` and editing it to
   reflect your postgres and other keys and credentials
 
   **Note:** In order for resets to work the postgres user specified in
-  the `.env` file needs to exist and have `CREATEDB` permissions.
+  the `.env.dev` file needs to exist and have `CREATEDB` permissions.
 
 * Run `make release` in the top level folder
 * Run `make reset` to initialize the database and reset the ledger. You will
@@ -31,6 +31,13 @@ listening for new block events.
 
 Once started the application will start syncing the blockchain and
 loading blocks into the attached database.
+
+You can change the release target (and .env file) using the `PROFILE`
+environment variable, which defaults to `dev`. i.e.:
+
+```
+PROFILE=testnet make start
+```
 
 #### Note
 You may see an error similar to the following during initial sync:

--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ You can change the release target (and .env file) using the `PROFILE`
 environment variable, which defaults to `dev`. i.e.:
 
 ```
-PROFILE=testnet make start
+make start -e PROFILE=testnet
 ```
 
 #### Note


### PR DESCRIPTION
Related to `.env` -> `.env.$PROFILE` switch from https://github.com/helium/blockchain-etl/commit/9059f18168d227e6e02e66607a9a54bbb4e4c27c

This felt simpler than refactoring code and adding conditionals, but it also means that existing installs using `.env` will still be broken if they update

