### PR TITLE
Switch back to .env instead of .env.dev

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -6,6 +6,7 @@ PKG_NAME_VER=${SHORTSHA}
 
 OS_NAME=$(shell uname -s)
 PROFILE ?= dev
+ENVFILE=$(if $(filter $(PROFILE),dev),'.env','.env.$(PROFILE)')
 
 ifeq (${OS_NAME},FreeBSD)
 make="gmake"
@@ -44,14 +45,14 @@ migrations: stop
 	./_build/$(PROFILE)/rel/blockchain_etl/bin/blockchain_etl migrations run
 
 start:
-	cp -f .env.$(PROFILE) ./_build/$(PROFILE)/rel/blockchain_etl/.env
+	cp -f $(ENVFILE) ./_build/$(PROFILE)/rel/blockchain_etl/.env
 	./_build/$(PROFILE)/rel/blockchain_etl/bin/blockchain_etl start
 
 stop:
 	-./_build/$(PROFILE)/rel/blockchain_etl/bin/blockchain_etl stop
 
 reset: stop
-	cp -f .env.$(PROFILE) ./_build/$(PROFILE)/rel/blockchain_etl/.env
+	cp -f $(ENVFILE) ./_build/$(PROFILE)/rel/blockchain_etl/.env
 	rm -rf ./_build/$(PROFILE)/rel/blockchain_etl/data/ledger.db
 	rm -rf ./_build/$(PROFILE)/rel/blockchain_etl/log/*
 	_build/$(PROFILE)/rel/blockchain_etl/bin/blockchain_etl migrations reset

--- a/README.md
+++ b/README.md
@@ -11,11 +11,11 @@ listening for new block events.
 ## Developer Usage
 
 * Clone this repository
-* Create `.env.dev` file by copying `.env.template` and editing it to
+* Create `.env` file by copying `.env.template` and editing it to
   reflect your postgres and other keys and credentials
 
   **Note:** In order for resets to work the postgres user specified in
-  the `.env.dev` file needs to exist and have `CREATEDB` permissions.
+  the `.env` file needs to exist and have `CREATEDB` permissions.
 
 * Run `make release` in the top level folder
 * Run `make reset` to initialize the database and reset the ledger. You will


### PR DESCRIPTION
Slightly more backwards-compatible, and makes more logical sense to me

Arguably could add some checks to favor ".env.dev" over ".env" if it exists? But this is already getting fancy
