### PR TITLE
ignore overages, since it doesn't collect like the others

### DIFF
--- a/src/be_db_reward.erl
+++ b/src/be_db_reward.erl
@@ -93,8 +93,10 @@ collect_rewards(blockchain_txn_rewards_v2, Chain, Txn, RewardMap) ->
         Chain
     ),
     maps:fold(
-        fun(_RewardCategory, Rewards, Acc) ->
-            collect_v2_rewards(Rewards, Ledger, Acc)
+        fun(overages, _Amount, Acc) ->
+                Acc;
+           (_RewardCategory, Rewards, Acc) ->
+                collect_v2_rewards(Rewards, Ledger, Acc)
         end,
         RewardMap,
         Metadata


### PR DESCRIPTION
overages in v2 crashes when it goes into collect v2, since it's an integer.  just ignore it, we can get it from the json later if we need it.