### PR TITLE
Only set failed status if current status is not cleared

### DIFF
--- a/src/be_db_pending_txn.erl
+++ b/src/be_db_pending_txn.erl
@@ -40,7 +40,8 @@ prepare_conn(Conn) ->
                      ["UPDATE pending_transactions SET ",
                       "status = 'failed', ",
                       "failed_reason = $2 ",
-                      "WHERE created_at = $1"],
+                      "WHERE created_at = $1 ",
+                      "AND status != 'cleared' "],
                      []),
 
     {ok, S5} =


### PR DESCRIPTION
Since the txn_mgr will retry transactions across elections, the transaction could clear while the txn mgr is sending retries which would then come back as failures.

This would cause the  pending_txn to be marked as failed after it had cleared.

This patch ensures that a failed status is only set if the current status is not already cleared