### PR TITLE
Changes two ms accuracy witness timestamps to strings

### DIFF
--- a/src/be_db_gateway.erl
+++ b/src/be_db_gateway.erl
@@ -175,10 +175,12 @@ witnesses_to_json(Witnesses) ->
 witness_to_json(Witness) ->
     #{
         <<"histogram">> => blockchain_ledger_gateway_v2:witness_hist(Witness),
-        <<"first_time">> => ?MAYBE_UNDEFINED(
+        <<"first_time">> => ?MAYBE_FN(
+            fun(V) -> integer_to_binary(V) end,
             blockchain_ledger_gateway_v2:witness_first_time(Witness)
         ),
-        <<"recent_time">> => ?MAYBE_UNDEFINED(
+        <<"recent_time">> => ?MAYBE_FN(
+            fun(V) -> integer_to_binary(V) end,
             blockchain_ledger_gateway_v2:witness_recent_time(Witness)
         )
     }.


### PR DESCRIPTION
Large integers are not well supported by JS which makes first_time and recent_time fail or warn loudly in some JS packages.

This changes these to strings so that JS implementations can choose to parse this with (for example) a bigint library, or ignorre it safely

Fixes #163 