### PR TITLE
Add location_hex for res (8) based hex lookups

### DIFF
--- a/migrations/1620768447-gateway_location_hex.sql
+++ b/migrations/1620768447-gateway_location_hex.sql
@@ -1,0 +1,76 @@
+-- migrations/1620768447-gateway_location_hex.sql
+-- :up
+
+alter table gateways
+    add column location_hex TEXT;
+
+alter table gateway_inventory
+    add column location_hex TEXT;
+
+CREATE OR REPLACE FUNCTION gateway_inventory_update()
+RETURNS TRIGGER AS $$
+BEGIN
+  insert into gateway_inventory as g
+         (address, name, owner, location,
+          last_poc_challenge, last_poc_onion_key_hash, witnesses, nonce,
+          first_block, last_block, first_timestamp, reward_scale,
+          elevation, gain, location_hex)
+  VALUES
+        (NEW.address, NEW.name, NEW.owner, NEW.location,
+        NEW.last_poc_challenge, NEW.last_poc_onion_key_hash, NEW.witnesses, NEW.nonce,
+        NEW.block, NEW.block, to_timestamp(NEW.time), NEW.reward_scale,
+        NEW.elevation, NEW.gain,
+        NEW.location_hex
+        )
+  ON CONFLICT (address) DO UPDATE SET
+       owner = EXCLUDED.owner,
+       location = EXCLUDED.location,
+       last_poc_challenge = EXCLUDED.last_poc_challenge,
+       last_poc_onion_key_hash = EXCLUDED.last_poc_onion_key_hash,
+       witnesses = EXCLUDED.witnesses,
+       nonce = EXCLUDED.nonce,
+       last_block = EXCLUDED.last_block,
+       reward_scale = COALESCE(EXCLUDED.reward_scale, g.reward_scale),
+       elevation = EXCLUDED.elevation,
+       gain = EXCLUDED.gain,
+       location_hex = EXCLUDED.location_hex;
+  RETURN NEW;
+END;
+$$ LANGUAGE plpgsql;
+
+-- :down
+
+CREATE OR REPLACE FUNCTION gateway_inventory_update()
+RETURNS TRIGGER AS $$
+BEGIN
+  insert into gateway_inventory as g
+         (address, name, owner, location,
+          last_poc_challenge, last_poc_onion_key_hash, witnesses, nonce,
+          first_block, last_block, first_timestamp, reward_scale,
+          elevation, gain)
+  VALUES
+        (NEW.address, NEW.name, NEW.owner, NEW.location,
+        NEW.last_poc_challenge, NEW.last_poc_onion_key_hash, NEW.witnesses, NEW.nonce,
+        NEW.block, NEW.block, to_timestamp(NEW.time), NEW.reward_scale,
+        NEW.elevation, NEW.gain
+        )
+  ON CONFLICT (address) DO UPDATE SET
+       owner = EXCLUDED.owner,
+       location = EXCLUDED.location,
+       last_poc_challenge = EXCLUDED.last_poc_challenge,
+       last_poc_onion_key_hash = EXCLUDED.last_poc_onion_key_hash,
+       witnesses = EXCLUDED.witnesses,
+       nonce = EXCLUDED.nonce,
+       last_block = EXCLUDED.last_block,
+       reward_scale = COALESCE(EXCLUDED.reward_scale, g.reward_scale),
+       elevation = EXCLUDED.elevation,
+       gain = EXCLUDED.gain;
+  RETURN NEW;
+END;
+$$ LANGUAGE plpgsql;
+
+alter table gateways
+    drop column location_hex;
+
+alter table gateway_inventory
+    drop column location_hex;

--- a/scripts/extensions/backfill
+++ b/scripts/extensions/backfill
@@ -15,6 +15,6 @@ done
 
 buf="${buf%?}]]"
 
-export NODETOOL_TIMEOUT=5400000
+export NODETOOL_TIMEOUT=54000000
 relx_nodetool rpc blockchain_console command "$buf"
 exit $?

--- a/src/be_cli_backfill.erl
+++ b/src/be_cli_backfill.erl
@@ -24,7 +24,8 @@ register_all_usage() ->
             backfill_gateway_names_usage(),
             backfill_oui_subnets_usage(),
             backfill_location_geometry_usage(),
-            backfill_reward_gateways_usage()
+            backfill_reward_gateways_usage(),
+            backfill_gateway_location_hex_usage()
         ]
     ).
 
@@ -40,7 +41,8 @@ register_all_cmds() ->
             backfill_gateway_names_cmd(),
             backfill_oui_subnets_cmd(),
             backfill_location_geometry_cmd(),
-            backfill_reward_gateways_cmd()
+            backfill_reward_gateways_cmd(),
+            backfill_gateway_location_hex_cmd()
         ]
     ).
 
@@ -59,6 +61,7 @@ backfill_usage() ->
             "  backfill oui_subnets            - Backfill OUI inventory subnets.\n"
             "  backfill location_geometry      - Backfill location postgis geometries.\n"
             "  backfill reward_gateways        - Backfill reward gateways.\n"
+            "  backfill gateways_location_hex  - Backfill location hex in gateway_inventory.\n"
         ]
     ].
 
@@ -303,4 +306,31 @@ backfill_reward_gateways(_CmdBase, Keys, _) ->
         MinBlock,
         MaxBlock
     ),
+    [clique_status:text(io_lib:format("Updated ~p", [Updated]))].
+
+%%
+%% backfill gateway_location_hex
+%%
+
+backfill_gateway_location_hex_cmd() ->
+    [
+        [
+            ["backfill", "gateway_location_hex"],
+            [],
+            [],
+            fun backfill_gateway_location_hex/3
+        ]
+    ].
+
+backfill_gateway_location_hex_usage() ->
+    [
+        ["backfill", "gateway_location_hex"],
+        [
+            "backfill location_hex \n\n",
+            "  Fixes NULL location_hex entries in the gateway_inventory table.\n\n"
+        ]
+    ].
+
+backfill_gateway_location_hex(_CmdBase, [], _) ->
+    Updated = be_db_backfill:gateway_location_hex(),
     [clique_status:text(io_lib:format("Updated ~p", [Updated]))].


### PR DESCRIPTION
This adds a location_hex column to gateways which allows for gateways to be grouped by a hardcoded h3 resolution (8 today). 

This is the etl side to support: https://github.com/helium/blockchain-http/issues/255