### PR TITLE
Fixes location_hex to be computed from lat/lon

### DIFF
--- a/src/be_db_backfill.erl
+++ b/src/be_db_backfill.erl
@@ -224,14 +224,14 @@ reward_gateways(MinBlock, MaxBlock) ->
     Inserted.
 
 %%
-%% Fill in gateway location_hes if they're null
+%% Fill in gateway location_hex
 %%
 
 gateway_location_hex() ->
     {ok, _, NoLocs} =
         ?EQUERY(
             [
-                "select address, location from gateway_inventory where location is not null and location_hex is null"
+                "select address, location from gateway_inventory where location is not null"
             ],
             []
         ),

--- a/src/be_db_gateway.erl
+++ b/src/be_db_gateway.erl
@@ -173,10 +173,7 @@ q_insert_gateway(BlockHeight, BlockTime, Address, GW, ChangeType, Ledger) ->
 
 -spec calculate_location_hex(h3:h3index()) -> h3:h3index().
 calculate_location_hex(Location) ->
-    case h3:get_resolution(Location) =< ?H3_LOCATION_RES of
-        true -> Location;
-        false -> h3:parent(Location, ?H3_LOCATION_RES)
-    end.
+    h3:from_geo(h3:to_geo(Location), ?H3_LOCATION_RES).
 
 witnesses_to_json(Witnesses) ->
     maps:fold(


### PR DESCRIPTION
instead of using get_parent

Fixes #189 