### PR TITLE
Fixing the recoding of the HTLC burn

### DIFF
--- a/src/be_db_dc_burn.erl
+++ b/src/be_db_dc_burn.erl
@@ -72,12 +72,14 @@ collect_burns(Block, OraclePrice, Ledger) ->
 %% Collect burn_type, actor and amount data for each
 collect_burns(blockchain_txn_oui_v1, Txn, Ledger, Acc) ->
     collect_fee(Txn, Ledger, [
-        {oui, blockchain_txn_oui_v1:fee_payer(Txn, Ledger), blockchain_txn_oui_v1:staking_fee(Txn)}
+        {oui, blockchain_txn_oui_v1:fee_payer(Txn, Ledger),
+            blockchain_txn_oui_v1:staking_fee(Txn)}
         | Acc
     ]);
 collect_burns(blockchain_txn_routing_v1, Txn, Ledger, Acc) ->
     collect_fee(Txn, Ledger, [
-        {routing, blockchain_txn_routing_v1:owner(Txn), blockchain_txn_routing_v1:staking_fee(Txn)}
+        {routing, blockchain_txn_routing_v1:owner(Txn), 
+            blockchain_txn_routing_v1:staking_fee(Txn)}
         | Acc
     ]);
 collect_burns(blockchain_txn_add_gateway_v1, Txn, Ledger, Acc) ->
@@ -96,6 +98,12 @@ collect_burns(blockchain_txn_assert_location_v2, Txn, Ledger, Acc) ->
     collect_fee(Txn, Ledger, [
         {assert_location, blockchain_txn_assert_location_v2:fee_payer(Txn, Ledger),
             blockchain_txn_assert_location_v2:staking_fee(Txn)}
+        | Acc
+    ]);
+collect_burns(blockchain_txn_create_htlc_v1, Txn, Ledger, Acc) ->
+    collect_fee(Txn, Ledger, [
+        {assert_location, blockchain_txn_create_htlc_v1:fee_payer(Txn, Ledger),
+            blockchain_txn_create_htlc_v1:staking_fee(Txn)}
         | Acc
     ]);
 collect_burns(blockchain_txn_state_channel_close_v1, Txn, Ledger, Acc) ->


### PR DESCRIPTION
The lines changed from 103-108. This adds the functionality to it.

The implicit burn was missing from the ETL, from HTLC transcations. Even thought the core had no problem with it.

I urge some caution, and need some review with this pull request, as I am unable to run an ETL to test transactions of this. As mine is about 400k blocks away, and needing a new hard drive soon.