### PR TITLE
Update gateway/validator status null entries

### DIFF
--- a/config/sys.config
+++ b/config/sys.config
@@ -10,10 +10,10 @@
             {pool, [
                 %% We keep the pool small since all blocks are handled in a
                 %% single transaction and the pending_txn_worker only needs one
-                %% as well. Gateway status works in parallel which requires
-                %% more connections
-                {size, 25},
-                {max_overflow, 10}
+                %% as well. Gateway and validator status works in parallel 
+                %% which requires more connections
+                {size, 50},
+                {max_overflow, 20}
             ]},
             {handlers, [
                 be_db_block,

--- a/src/be_db_gateway_status.erl
+++ b/src/be_db_gateway_status.erl
@@ -77,7 +77,7 @@ prepare_conn(Conn) ->
                 "    < (now() - '",
                 integer_to_list(?STATUS_REFRESH_MINS),
                 " minute'::interval) ",
-                "order by s.updated_at ",
+                "order by coalesce(updated_at, to_timestamp(0)) ",
                 "limit $1"
             ],
             []

--- a/src/be_db_validator_status.erl
+++ b/src/be_db_validator_status.erl
@@ -75,7 +75,7 @@ prepare_conn(Conn) ->
                 "    < (now() - '",
                 integer_to_list(?STATUS_REFRESH_MINS),
                 " minute'::interval) ",
-                "order by s.updated_at ",
+                "order by coalesce(updated_at, to_timestamp(0)) ",
                 "limit $1"
             ],
             []
@@ -97,7 +97,7 @@ prepare_conn(Conn) ->
                 "    online = EXCLUDED.online,",
                 "    block = coalesce(EXCLUDED.block, status.block),"
                 "    peer_timestamp = coalesce(EXCLUDED.peer_timestamp, status.peer_timestamp),",
-                "    listen_addrs = EXCLUDED.listen_addrs;"
+                "    listen_addrs = coalesce(EXCLUDED.listen_addrs, stsatus.listen_addrs);"
             ],
             []
         ),

--- a/src/be_db_validator_status.erl
+++ b/src/be_db_validator_status.erl
@@ -97,7 +97,7 @@ prepare_conn(Conn) ->
                 "    online = EXCLUDED.online,",
                 "    block = coalesce(EXCLUDED.block, status.block),"
                 "    peer_timestamp = coalesce(EXCLUDED.peer_timestamp, status.peer_timestamp),",
-                "    listen_addrs = coalesce(EXCLUDED.listen_addrs, stsatus.listen_addrs);"
+                "    listen_addrs = coalesce(EXCLUDED.listen_addrs, status.listen_addrs);"
             ],
             []
         ),


### PR DESCRIPTION
* Orders null entries the same way selection is done
* Increase the number of connections to the db pool to ease up pool pressure