### PR TITLE
Hack to one time memoize reward metadata

### DIFF
--- a/config/sys.config
+++ b/config/sys.config
@@ -94,7 +94,7 @@
         {seed_nodes,
             "/ip4/35.166.211.46/tcp/2154,/ip4/44.236.95.167/tcp/2154,/ip4/3.34.61.168/tcp/2154"},
         {disable_gateway_cache, true},
-        {sync_timeout_mins, 10},
+        {sync_timeout_mins, 15},
         {max_inbound_connections, 32},
         {outbound_gossip_connections, 4},
         {peerbook_update_interval, 180000}

--- a/config/sys.config
+++ b/config/sys.config
@@ -12,8 +12,8 @@
                 %% single transaction and the pending_txn_worker only needs one
                 %% as well. Gateway and validator status works in parallel
                 %% which requires more connections
-                {size, 50},
-                {max_overflow, 20}
+                {size, 100},
+                {max_overflow, 30}
             ]},
             {handlers, [
                 be_db_block,

--- a/config/sys.config
+++ b/config/sys.config
@@ -12,8 +12,8 @@
                 %% single transaction and the pending_txn_worker only needs one
                 %% as well. Gateway and validator status works in parallel
                 %% which requires more connections
-                {size, 60},
-                {max_overflow, 20}
+                {size, 100},
+                {max_overflow, 30}
             ]},
             {handlers, [
                 be_db_block,

--- a/config/sys.config
+++ b/config/sys.config
@@ -12,8 +12,8 @@
                 %% single transaction and the pending_txn_worker only needs one
                 %% as well. Gateway and validator status works in parallel
                 %% which requires more connections
-                {size, 100},
-                {max_overflow, 30}
+                {size, 50},
+                {max_overflow, 20}
             ]},
             {handlers, [
                 be_db_block,

--- a/config/sys.config
+++ b/config/sys.config
@@ -12,8 +12,8 @@
                 %% single transaction and the pending_txn_worker only needs one
                 %% as well. Gateway and validator status works in parallel
                 %% which requires more connections
-                {size, 100},
-                {max_overflow, 30}
+                {size, 60},
+                {max_overflow, 20}
             ]},
             {handlers, [
                 be_db_block,

--- a/src/be_db_account.erl
+++ b/src/be_db_account.erl
@@ -80,7 +80,7 @@ load_block(Conn, _Hash, Block, _Sync, Ledger, State = #state{}) ->
         #{},
         Ledger
     ),
-    be_db_follower:maybe_log_duration(accound_staked_make, StartStaked),
+    be_db_follower:maybe_log_duration(db_account_staked_make, StartStaked),
 
     UpdateAccount = fun(Account) ->
         lists:foldl(
@@ -111,7 +111,7 @@ load_block(Conn, _Hash, Block, _Sync, Ledger, State = #state{}) ->
         #{},
         Block
     ),
-    be_db_follower:maybe_log_duration(accound_actor_fold, StartActor),
+    be_db_follower:maybe_log_duration(db_account_actor_fold, StartActor),
 
     %% Merge in any accounts that are indirectly updated by the ledger and stashed
     %% in the module ets table
@@ -132,7 +132,7 @@ load_block(Conn, _Hash, Block, _Sync, Ledger, State = #state{}) ->
         BlockAccounts,
         ?MODULE
     ),
-    be_db_follower:maybe_log_duration(accound_unhandled_fold, StartUnhandled),
+    be_db_follower:maybe_log_duration(db_account_unhandled_fold, StartUnhandled),
 
     StartMkQuery = erlang:monotonic_time(millisecond),
     BlockHeight = blockchain_block_v1:height(Block),
@@ -143,11 +143,11 @@ load_block(Conn, _Hash, Block, _Sync, Ledger, State = #state{}) ->
         [],
         Accounts
     ),
-    be_db_follower:maybe_log_duration(accound_query_make, StartMkQuery),
+    be_db_follower:maybe_log_duration(db_account_query_make, StartMkQuery),
 
     StartQuery = erlang:monotonic_time(millisecond),
     ok = ?BATCH_QUERY(Conn, Queries),
-    be_db_follower:maybe_log_duration(accound_query_exec, StartQuery),
+    be_db_follower:maybe_log_duration(db_account_query_exec, StartQuery),
 
     ets:delete_all_objects(?MODULE),
     {ok, State}.

--- a/src/be_db_follower.erl
+++ b/src/be_db_follower.erl
@@ -87,8 +87,10 @@ load_block(Hash, Block, Sync, Ledger, State = #state{}) ->
         States =
             lists:foldl(
                 fun({Handler, HandlerState}, HandlerStates) ->
+                    Start = erlang:monotonic_time(millisecond),
                     {ok, NewHandlerState} =
                         Handler:load_block(Conn, Hash, Block, Sync, Ledger, HandlerState),
+                    maybe_log_duration(Handler, Start),
                     [{Handler, NewHandlerState} | HandlerStates]
                 end,
                 [],
@@ -97,8 +99,11 @@ load_block(Hash, Block, Sync, Ledger, State = #state{}) ->
         {ok, lists:reverse(States)}
     end,
 
+    Start = erlang:monotonic_time(millisecond),
     lager:info("Storing block: ~p", [blockchain_block_v1:height(Block)]),
     {ok, HandlerStates} = ?WITH_TRANSACTION(LoadFun),
+    End = erlang:monotonic_time(millisecond),
+    lager:info("Stored block: ~p took: ~p ms", [blockchain_block_v1:height(Block), End - Start]),
     {ok, #state{handler_state = HandlerStates}}.
 
 terminate(_Reason, _State) ->
@@ -107,6 +112,15 @@ terminate(_Reason, _State) ->
 %%
 %% Utilities
 %%
+
+maybe_log_duration(Item, Start) ->
+    case application:get_env(blockchain_etl, log_handler_duration, true) of
+        true ->
+            End = erlang:monotonic_time(millisecond),
+            lager:info("~p took ~p ms", [Item, End - Start]);
+        _ ->
+            ok
+    end.
 
 fold_actors(Roles, Fun, InitAcc, Block) ->
     Txns = blockchain_block_v1:transactions(Block),

--- a/src/be_db_follower.erl
+++ b/src/be_db_follower.erl
@@ -35,7 +35,8 @@
     maybe_b64/1,
     maybe_b58/1,
     maybe_h3/1,
-    random_val_predicate/1
+    random_val_predicate/1,
+    maybe_log_duration/2
 ]).
 
 -define(HANDLER_MODULES, [

--- a/src/be_db_reward.erl
+++ b/src/be_db_reward.erl
@@ -6,6 +6,8 @@
 -export([prepare_conn/1]).
 %% be_block_handler
 -export([init/1, load_block/6]).
+%% api
+-export([calculate_rewards_metadata/3]).
 
 -behavior(be_db_worker).
 -behavior(be_db_follower).
@@ -35,6 +37,7 @@ prepare_conn(Conn) ->
 %%
 
 init(_) ->
+    ets:new(?MODULE, [public, named_table]),
     {ok, #state{}}.
 
 load_block(Conn, _Hash, Block, _Sync, _Ledger, State = #state{}) ->
@@ -81,13 +84,29 @@ load_block(Conn, _Hash, Block, _Sync, _Ledger, State = #state{}) ->
         Reward :: pos_integer()
 }.
 
+calculate_rewards_metadata(Start, End, Chain) ->
+    % This makes the terrible assumption that there are only two users of
+    % rewards metadata.
+    case ets:take(?MODULE, metadata) of
+        [] ->
+            {ok, Metadata} = blockchain_txn_rewards_v2:calculate_rewards_metadata(
+                Start,
+                End,
+                Chain
+            ),
+            ets:insert(?MODULE, {metadata, Metadata}),
+            {ok, Metadata};
+        [{metadata, Metadata}] ->
+            {ok, Metadata}
+    end.
+
 collect_rewards(blockchain_txn_rewards_v1, _Chain, Txn, RewardMap) ->
     collect_v1_rewards(blockchain_txn_rewards_v1:rewards(Txn), RewardMap);
 collect_rewards(blockchain_txn_rewards_v2, Chain, Txn, RewardMap) ->
     Start = blockchain_txn_rewards_v2:start_epoch(Txn),
     End = blockchain_txn_rewards_v2:end_epoch(Txn),
     {ok, Ledger} = blockchain:ledger_at(End, Chain),
-    {ok, Metadata} = blockchain_txn_rewards_v2:calculate_rewards_metadata(
+    {ok, Metadata} = ?MODULE:calculate_rewards_metadata(
         Start,
         End,
         Chain

--- a/src/be_db_reward.erl
+++ b/src/be_db_reward.erl
@@ -89,11 +89,14 @@ calculate_rewards_metadata(Start, End, Chain) ->
     % rewards metadata.
     case ets:take(?MODULE, metadata) of
         [] ->
+            Start = erlang:monotonic_time(millisecond),
             {ok, Metadata} = blockchain_txn_rewards_v2:calculate_rewards_metadata(
                 Start,
                 End,
                 Chain
             ),
+            End = erlang:monotonic_time(millisecond),
+            lager:info("Calculated rewards metadata took: ~p ms", [End - Start]),
             ets:insert(?MODULE, {metadata, Metadata}),
             {ok, Metadata};
         [{metadata, Metadata}] ->

--- a/src/be_db_reward.erl
+++ b/src/be_db_reward.erl
@@ -89,14 +89,14 @@ calculate_rewards_metadata(Start, End, Chain) ->
     % rewards metadata.
     case ets:take(?MODULE, metadata) of
         [] ->
-            Start = erlang:monotonic_time(millisecond),
+            StartTime = erlang:monotonic_time(millisecond),
             {ok, Metadata} = blockchain_txn_rewards_v2:calculate_rewards_metadata(
                 Start,
                 End,
                 Chain
             ),
-            End = erlang:monotonic_time(millisecond),
-            lager:info("Calculated rewards metadata took: ~p ms", [End - Start]),
+            EndTime = erlang:monotonic_time(millisecond),
+            lager:info("Calculated rewards metadata took: ~p ms", [EndTime - StartTime]),
             ets:insert(?MODULE, {metadata, Metadata}),
             {ok, Metadata};
         [{metadata, Metadata}] ->

--- a/src/be_db_txn_actor.erl
+++ b/src/be_db_txn_actor.erl
@@ -220,7 +220,7 @@ to_actors(blockchain_txn_rewards_v2, T) ->
     %% ledger to construct it actors
     Chain = blockchain_worker:blockchain(),
     {ok, Ledger} = blockchain:ledger_at(End, Chain),
-    {ok, Metadata} = blockchain_txn_rewards_v2:calculate_rewards_metadata(
+    {ok, Metadata} = be_db_reward:calculate_rewards_metadata(
         Start,
         End,
         Chain


### PR DESCRIPTION
This makes the terrible assumption that there are only two users of rewards metadata.

Using an ets table as a way to hand of a rewards table between to disjoint pieces of code is terrible but maybe it'll help