### PR TITLE
Ignore disputed state channel txn

### DIFF
--- a/src/be_db_dc_burn.erl
+++ b/src/be_db_dc_burn.erl
@@ -27,6 +27,7 @@ prepare_conn(Conn) ->
         [
             "insert into dc_burns (block, time, transaction_hash, actor, type, amount, oracle_price) ",
             "values ($1, $2, $3, $4, $5, $6, $7) "
+            "on conflict do nothing"
         ],
         []
     ),


### PR DESCRIPTION
When a state channel is disputed the same txn hash and actors may happen. This will cause dc burns to fail inserting.

This hack ignores dc burns duplicates to avoid etl falling over