### PR TITLE
Extend the address component search to all entries

### DIFF
--- a/src/be_cli_backfill.erl
+++ b/src/be_cli_backfill.erl
@@ -28,7 +28,8 @@ register_all_usage() ->
             backfill_gateway_location_hex_usage(),
             backfill_dc_burn_usage(),
             backfill_gateway_payers_usage(),
-            backfill_consensus_failure_members_usage()
+            backfill_consensus_failure_members_usage(),
+            backfill_gateway_location_clear_nulls_usage()
         ]
     ).
 
@@ -48,7 +49,8 @@ register_all_cmds() ->
             backfill_gateway_location_hex_cmd(),
             backfill_dc_burn_cmd(),
             backfill_gateway_payers_cmd(),
-            backfill_consensus_failure_members_cmd()
+            backfill_consensus_failure_members_cmd(),
+            backfill_gateway_location_clear_nulls_cmd()
         ]
     ).
 
@@ -61,16 +63,17 @@ backfill_usage() ->
         ["backfill"],
         [
             "backfill commands\n\n",
-            "  backfill receipts_challenger       - Backfill the challenger for receipts transactions.\n",
-            "  backfill reversed_receipts_path    - Backfill fix reversed poc receipts paths.\n",
-            "  backfill gateway_names             - Backfill names in gateway_inventory.\n"
-            "  backfill oui_subnets               - Backfill OUI inventory subnets.\n"
-            "  backfill location_geometry         - Backfill location postgis geometries.\n"
-            "  backfill reward_gateways           - Backfill reward gateways.\n"
-            "  backfill gateway_location_hex      - Backfill location hex in gateway_inventory.\n"
-            "  backfill dc_burn                   - Backfill DC burn table.\n"
-            "  backfill gateway_payers            - Backfill payers in gateway_inventory.\n"
-            "  backfill consensus_failure_members - Backfill consensus failure actors.\n"
+            "  backfill receipts_challenger          - Backfill the challenger for receipts transactions.\n",
+            "  backfill reversed_receipts_path       - Backfill fix reversed poc receipts paths.\n",
+            "  backfill gateway_names                - Backfill names in gateway_inventory.\n"
+            "  backfill oui_subnets                  - Backfill OUI inventory subnets.\n"
+            "  backfill location_geometry            - Backfill location postgis geometries.\n"
+            "  backfill reward_gateways              - Backfill reward gateways.\n"
+            "  backfill gateway_location_hex         - Backfill location hex in gateway_inventory.\n"
+            "  backfill dc_burn                      - Backfill DC burn table.\n"
+            "  backfill gateway_payers               - Backfill payers in gateway_inventory.\n"
+            "  backfill consensus_failure_members    - Backfill consensus failure actors.\n"
+            "  backfill gateway_location_clear_nulls - CLear location entries with null address components.\n"
         ]
     ].
 
@@ -439,3 +442,29 @@ backfill_consensus_failure_members_usage() ->
 backfill_consensus_failure_members(_CmdBase, [], []) ->
     Updated = be_db_backfill:consensus_failure_members(),
     [clique_status:text(io_lib:format("Updated ~p", [Updated]))].
+
+%%
+%% backfill gateway_location_clear_nulls
+%%
+
+backfill_gateway_location_clear_nulls_cmd() ->
+    [
+        [
+            ["backfill", "gateway_location_clear_nulls"],
+            [],
+            [],
+            fun backfill_gateway_location_clear_nulls/3
+        ]
+    ].
+
+backfill_gateway_location_clear_nulls_usage() ->
+    [
+        ["backfill", "gateway_location_clear_nulls"],
+        [
+            "Remove location rows with null address components.\n\n"
+        ]
+    ].
+
+backfill_gateway_location_clear_nulls(_CmdBase, [], []) ->
+    Deleted = be_db_backfill:gateway_location_clear_nulls(),
+    [clique_status:text(io_lib:format("Deleted ~p", [Deleted]))].

--- a/src/be_db_backfill.erl
+++ b/src/be_db_backfill.erl
@@ -14,7 +14,8 @@
     dc_burn/2,
     oracle_price_at/1,
     gateway_payers/0,
-    consensus_failure_members/0
+    consensus_failure_members/0,
+    gateway_location_clear_nulls/0
 ]).
 
 -define(INSERT_RECEIPTS_CHALLENGERS, [
@@ -402,3 +403,22 @@ consensus_failure_members() ->
         0,
         Blocks
     ).
+
+%%
+%% Remove location rows with null street, city, state, country columns. The
+%% geocoder will backfill as needed.
+%%
+
+gateway_location_clear_nulls() ->
+    {ok, Deleted} = ?EQUERY(
+        [
+            "delete from locations ",
+            "where ",
+            "short_street is null || long_street is null || ",
+            "short_city is null || long_city is null || ",
+            "short_state is null || long_state is null || ",
+            "short_country is null || long_country is null "
+        ],
+        []
+    ),
+    Deleted.


### PR DESCRIPTION
Only the first address components of the result list was previously searched for geocode fields.

This change has it search all address component entries in order for the first one that has a result for both long _and_ short name.

After deploying this delete all rows in the locations table with a null short/long entry by running `backfill gateway_location_clear_nulls`. The geocoder will re-geocode the missing rows. 

Fixes #235 
