### PR TITLE
Use parent h3 instead of to/from_geo

### DIFF
--- a/src/be_cli_backfill.erl
+++ b/src/be_cli_backfill.erl
@@ -339,7 +339,7 @@ backfill_gateway_location_hex_usage() ->
         ["backfill", "gateway_location_hex"],
         [
             "backfill location_hex \n\n",
-            "  Fixes NULL location_hex entries in the gateway_inventory table.\n\n"
+            "  Fixes all location_hex entries in the gateway_inventory table.\n\n"
         ]
     ].
 

--- a/src/be_db_gateway.erl
+++ b/src/be_db_gateway.erl
@@ -187,7 +187,7 @@ q_insert_gateway(BlockHeight, BlockTime, Address, GW, ChangeType, Ledger) ->
 
 -spec calculate_location_hex(h3:h3index()) -> h3:h3index().
 calculate_location_hex(Location) ->
-    h3:from_geo(h3:to_geo(Location), ?H3_LOCATION_RES).
+    h3:parent(Location, ?H3_LOCATION_RES).
 
 witnesses_to_json(Witnesses) ->
     maps:fold(


### PR DESCRIPTION
This switches to using h3:parent to move from res12 to res8 to match what the PoC core does with targeting.

**NOTE** This change _also_ requires the `gateway_location_hex` to be re-run, which will take about 5 minutes in the background for 200k hotspots

Fixes #191 