### PR TITLE
write latest height and hash for s3 sync

### DIFF
--- a/src/be_db_block.erl
+++ b/src/be_db_block.erl
@@ -144,7 +144,7 @@ maybe_write_snapshot(Height, SnapshotHash, SnapshotDir, Chain) ->
         end,
     LatestBin = jsone:encode(#{height => Height,
                                hash => base64url:encode(SnapshotHash)}),
-    Latest = filename:join([SnapshotDir, "latest-snapshot.json"]),
+    Latest = filename:join([SnapshotDir, "latest-snap.json"]),
     Filename = filename:join([SnapshotDir, io_lib:format("snap-~p", [Height])]),
     ok = file:write_file(Filename, BinSnap),
     ok = file:write_file(Latest, LatestBin).


### PR DESCRIPTION
since hotspots are no longer in consensus, this should be relatively safe; the miner side should allow manufacturers to supply their own URL for this data.