### PR TITLE
Add support for transfer_hotspot_v2

### DIFF
--- a/migrations/1635079118-transfer_hotspot_v2.sql
+++ b/migrations/1635079118-transfer_hotspot_v2.sql
@@ -1,0 +1,5 @@
+-- migrations/1635079118-transfer_hotspot_v2.sql
+-- :up
+
+ALTER TYPE transaction_type ADD VALUE 'transfer_hotspot_v2';
+

--- a/src/be_db_txn_actor.erl
+++ b/src/be_db_txn_actor.erl
@@ -322,6 +322,11 @@ to_actors(blockchain_txn_transfer_hotspot_v1, T) ->
         {"payer", blockchain_txn_transfer_hotspot_v1:buyer(T)},
         {"owner", blockchain_txn_transfer_hotspot_v1:buyer(T)}
     ];
+to_actors(blockchain_txn_transfer_hotspot_v2, T) ->
+    [
+        {"gateway", blockchain_txn_transfer_hotspot_v2:gateway(T)},
+        {"owner", blockchain_txn_transfer_hotspot_v2:new_owner(T)}
+    ];
 to_actors(blockchain_txn_gen_validator_v1, T) ->
     [
         {"validator", blockchain_txn_gen_validator_v1:address(T)},


### PR DESCRIPTION
This adds support for the transfer_hotspot_v2 transaction. 

**NOTE**: This requires a migration to be run