### PR TITLE
bump core and assumed valid block hash

### DIFF
--- a/config/sys.config
+++ b/config/sys.config
@@ -64,10 +64,10 @@
         {honor_quick_sync, true},
         {quick_sync_mode, assumed_valid},
 
-        {assumed_valid_block_height, 1079735},
+        {assumed_valid_block_height, 1105866},
         {assumed_valid_block_hash,
-            <<169, 127, 198, 154, 252, 138, 89, 134, 185, 134, 37, 28, 98, 10, 51, 159, 36, 18, 121,
-                13, 67, 145, 111, 85, 217, 172, 225, 248, 188, 112, 60, 67>>},
+            <<200, 48, 195, 30, 10, 94, 146, 242, 131, 163, 116, 138, 121, 7, 34, 109, 132, 130,
+                168, 216, 159, 166, 65, 140, 230, 170, 133, 234, 199, 130, 193, 95>>},
 
         {commit_hook_callbacks, [
             {entries, undefined, fun be_db_account:incremental_commit_hook/1,

--- a/rebar.config
+++ b/rebar.config
@@ -23,7 +23,7 @@
     {telemetry, "0.4.1"},
     {psql_migration, {git, "https://github.com/helium/psql-migration.git", {branch, "master"}}},
     {clique, {git, "https://github.com/helium/clique.git", {branch, "develop"}}},
-    {blockchain, {git, "https://github.com/helium/blockchain-core.git", {tag, "2021.11.18.0"}}},
+    {blockchain, {git, "https://github.com/helium/blockchain-core.git", {tag, "2021.11.21.1"}}},
     {envloader, {git, "https://github.com/nuex/envloader.git", {branch, "master"}}}
 ]}.
 

--- a/rebar.lock
+++ b/rebar.lock
@@ -5,7 +5,7 @@
  {<<"base64url">>,{pkg,<<"base64url">>,<<"1.0.1">>},0},
  {<<"blockchain">>,
   {git,"https://github.com/helium/blockchain-core.git",
-       {ref,"8a3b7eab5bc99b2b8bfdb66f484a107424157d92"}},
+       {ref,"2aaabe2afd92ffeb789572957a8c6f33479aeb17"}},
   0},
  {<<"certifi">>,{pkg,<<"certifi">>,<<"2.8.0">>},1},
  {<<"chatterbox">>,


### PR DESCRIPTION
This upgrades core to 2021.11.21.1 to work add some more critical performance improvements under heavy transaction load