### PR TITLE
updating dependencies and optimizing docker build

### DIFF
--- a/config/sys.config
+++ b/config/sys.config
@@ -90,7 +90,7 @@
         {autoload, false},
         {num_consensus_members, 16},
         {seed_nodes,
-            "/ip4/18.217.27.26/tcp/2154,/ip4/35.161.222.43/tcp/443,/ip4/99.80.158.114/tcp/2154"},
+            "/ip4/18.217.27.26/tcp/2154,/ip4/35.161.222.43/tcp/443,/ip4/99.80.158.114/tcp/2154,/ip4/3.66.43.167/tcp/443,/ip4/52.220.121.45/tcp/2154,/ip4/54.207.252.240/tcp/443,/ip4/3.34.10.207/tcp/2154,/ip4/13.238.174.45/tcp/443"},
         {disable_gateway_cache, true},
         {sync_timeout_mins, 15},
         {max_inbound_connections, 32},


### PR DESCRIPTION
Optimizing the docker build to pre-compile dependencies in a separate stage so they can be cached in a separate layer so long as there have been no changes to the rebar.config/rebar.lock files.

Also bumps the latest release of blockchain-core that patches a peer gossip bug related to allowance of rfc1918 addresses.