### PR TITLE
Adding dockerignore file

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,3 @@
+_build/
+.buildkite/
+.git/


### PR DESCRIPTION
Adding dockerignore file to prevent locally compiled builds of the app from populating build images when the source directory is copied into the container for compilation.