### PR TITLE
Attempt to restart the service 3 times

### DIFF
--- a/deb/blockchain-etl.service
+++ b/deb/blockchain-etl.service
@@ -1,6 +1,8 @@
 [Unit]
 Description=Blockchain ETL application
 After=network.target
+StartLimitInterval=60
+StartLimitBurst=3
 
 [Service]
 Type=simple
@@ -14,6 +16,8 @@ Environment=ERL_CRASH_DUMP="/var/data/log/blockchain_etl"
 LimitNOFILE=200000
 LimitNPROC=200000
 Restart=always
+RestartSec=15
+
 
 [Install]
 WantedBy=multi-user.target


### PR DESCRIPTION
Problem to solve: Currently systemd will attempt to start the service over and over, even if it keeps crashing. We would like for it to eventually give up if it goes into a failed state.

Solution: Limit restart attempts to 3 times, each one lasting 15 seconds apart, for up to 60 seconds. If the service is still not running by then, enter the failed state and do not attempt to restart until a human does something.