### PR TITLE
remove and retry creating corrupted dets cache file

### DIFF
--- a/src/be_db_gateway.erl
+++ b/src/be_db_gateway.erl
@@ -62,7 +62,7 @@ init(_) ->
     case dets:open_file(?MODULE, [{file, DetsFile}]) of
         {ok, ?MODULE} -> ok;
         {error, {not_a_dets_file, _}} ->
-            lager:warn("Failed to open dets file; unrecognized type"),
+            lager:warning("Failed to open dets file; unrecognized type"),
             ok = file:delete(DetsFile),
             {ok, ?MODULE} = dets:open_file(?MODULE, [{file, DetsFile}])
     end,


### PR DESCRIPTION
In the event the dets cache file the be_db_gateway handler writes to becomes corrupt, this file cannot be opened successfully in the init function. 

This change attempts to delete and re-create the file if it becomes corrupted or otherwise unrecognizable as a dets file