### PR TITLE
updating assumed valid block info to latest consensus generated snapshot

### DIFF
--- a/config/sys.config
+++ b/config/sys.config
@@ -64,10 +64,10 @@
         {honor_quick_sync, true},
         {quick_sync_mode, assumed_valid},
 
-        {assumed_valid_block_height, 1135381},
+        {assumed_valid_block_height, 1228990},
         {assumed_valid_block_hash,
-            <<237, 130, 117, 156, 155, 202, 249, 212, 29, 104, 115, 227, 118, 152, 205, 8, 172, 150,
-                155, 104, 123, 49, 24, 87, 51, 23, 218, 155, 208, 219, 93, 194>>},
+            <<146, 103, 238, 181, 173, 125, 214, 58, 113, 89, 11, 246, 24, 125, 244, 200, 72,
+                5, 184, 152, 40, 106, 105, 177, 95, 86, 144, 45, 189, 250, 80, 123>>},
 
         {commit_hook_callbacks, [
             {entries, undefined, fun be_db_account:incremental_commit_hook/1,


### PR DESCRIPTION
It's been a while since the consensus group has generated a snapshot of the chain through agreement automatically so this assumed_valid block info hasn't been updated in a while. Bumping the binary and the height to the most recently generated one from a CG running primarily validator 1.7.0