### PR TITLE
Stop storing uncompressed snapshots

### DIFF
--- a/src/be_db_block.erl
+++ b/src/be_db_block.erl
@@ -143,7 +143,7 @@ maybe_write_snapshot(Height, SnapshotHash, SnapshotDir, Chain) ->
             Other -> Other
         end,
     Filename = filename:join([SnapshotDir, io_lib:format("snap-~p", [Height])]),
-    ok = blockchain:save_bin_snapshot(Filename, BinSnap),
+    %% ok = blockchain:save_bin_snapshot(Filename, BinSnap),
     ok = blockchain:save_compressed_bin_snapshot(Filename, BinSnap), %% function adds ".gz"
     {ok, FileSHA} = blockchain:hash_bin_snapshot(BinSnap),
     Size = blockchain:size_bin_snapshot(BinSnap),


### PR DESCRIPTION
For immediate usage. #311 can be adopted too.