### PR TITLE
speed up S_STATUS_UNKNOWN_LIST

### DIFF
--- a/src/be_db_gateway_status.erl
+++ b/src/be_db_gateway_status.erl
@@ -73,11 +73,11 @@ prepare_conn(Conn) ->
             [
                 "select g.address from gateway_inventory g",
                 "  left join gateway_status s on s.address = g.address ",
-                "where coalesce(updated_at, to_timestamp(0)) ",
+                "where updated_at ",
                 "    < (now() - '",
                 integer_to_list(?STATUS_REFRESH_MINS),
                 " minute'::interval) ",
-                "order by coalesce(updated_at, to_timestamp(0)) ",
+                "order by updated_at ",
                 "limit $1"
             ],
             []


### PR DESCRIPTION
remove coalesce so indexes are used, updated_at is already not null + default now() so the coalesce to default to_timestamp(0) isn't needed