### PR TITLE
Fixes first_block for accounts

### DIFF
--- a/migrations/1650412999-account_owner_first_block.sql
+++ b/migrations/1650412999-account_owner_first_block.sql
@@ -1,0 +1,16 @@
+-- migrations/1650412999-account_owner_first_block.sql
+-- :up
+
+update account_inventory set first_block=subquery.first_block
+       from (
+            select address, first_block from (
+                select 
+                    address, 
+                    first_block as current, 
+                    (select max(block) from transaction_actors
+                        where actor_role = 'owner' and actor = i.address
+                    ) as first_block from account_inventory i
+            ) s where s.first_block is not null and s.first_block < s.current 
+        ) as subquery
+where account_inventory.address=subquery.address;
+

--- a/src/be_db_account.erl
+++ b/src/be_db_account.erl
@@ -103,7 +103,7 @@ load_block(Conn, _Hash, Block, _Sync, Ledger, State = #state{}) ->
     %% transaction actors
     StartActor = erlang:monotonic_time(millisecond),
     BlockAccounts = be_db_follower:fold_actors(
-        ["payer", "payee"],
+        ["payer", "payee", "owner"],
         fun({_Role, Key}, Acc) ->
             Account = maps:get(Key, Acc, #account{address = Key}),
             maps:put(Key, UpdateAccount(Account), Acc)


### PR DESCRIPTION
Account roles were failing to include transactions that affected the account “activity“but where not payment related. add_gateway, transfer_hotspot_v2 to a new account address were primary victims of this.

This adds the “owner” actor as a trigger for a new account row insert which will fix it for new accounts.

It also adds a migration that fixes up any account’s first_block fields,  that have “owner” actor entries before the first payment activity.

Fixes https://github.com/helium/blockchain-http/issues/412
Fixes https://github.com/helium/blockchain-http/issues/421
