### PR TITLE
Changes the online storage to match http

### DIFF
--- a/migrations/1650926462-gateway_last_block.sql
+++ b/migrations/1650926462-gateway_last_block.sql
@@ -1,0 +1,13 @@
+-- migrations/1650926462-gateway_last_block.sql
+-- :up
+
+update gateway_inventory set last_block=subquery.last_block
+       from (
+            select 
+                address, 
+                (select max(block) from transaction_actors
+                    where actor = i.address
+                ) as last_block 
+            from gateway_inventory i
+        ) as subquery
+where gateway_inventory.address=subquery.address;

--- a/src/be_db_gateway_status.erl
+++ b/src/be_db_gateway_status.erl
@@ -67,13 +67,12 @@ prepare_conn(Conn) ->
             Conn,
             ?S_STATUS_UNKNOWN_LIST,
             [
-                "select g.address, g.first_block, g.last_block from gateway_inventory g",
+                "select g.address, g.first_block, (select max(block) from transaction_actors a where a.address = g.address) as last_block from gateway_inventory g",
                 "  left join gateway_status s on s.address = g.address ",
                 "where coalesce(updated_at, to_timestamp(0)) ",
                 "    < (now() - '",
                 integer_to_list(?STATUS_REFRESH_MINS),
                 " minute'::interval) ",
-                "order by coalesce(updated_at, to_timestamp(0)) ",
                 "limit $1"
             ],
             []

--- a/src/be_db_gateway_status.erl
+++ b/src/be_db_gateway_status.erl
@@ -67,7 +67,7 @@ prepare_conn(Conn) ->
             Conn,
             ?S_STATUS_UNKNOWN_LIST,
             [
-                "select g.address, g.first_block, (select max(block) from transaction_actors a where a.address = g.address) as last_block from gateway_inventory g",
+                "select g.address, g.first_block, g.last_block from gateway_inventory g",
                 "  left join gateway_status s on s.address = g.address ",
                 "where coalesce(updated_at, to_timestamp(0)) ",
                 "    < (now() - '",

--- a/src/be_peer_status.erl
+++ b/src/be_peer_status.erl
@@ -4,11 +4,9 @@
 
 -export([
     peer_last_challenge/2,
-    peer_recent_challenger/2,
     peer_time/2,
     peer_metadata/3,
     peer_height/2,
-    peer_stale/3,
     peer_listen_addrs/2,
     peer_release_version/2
 ]).
@@ -22,18 +20,6 @@ peer_last_challenge(Address, Ledger) ->
     case blockchain_ledger_v1:find_gateway_info(Address, Ledger) of
         {error, _} -> undefined;
         {ok, GWInfo} -> blockchain_ledger_gateway_v2:last_poc_challenge(GWInfo)
-    end.
-
-peer_recent_challenger(Address, Ledger) ->
-    {ok, Height} = blockchain_ledger_v1:current_height(Ledger),
-    PoCInterval = blockchain_utils:challenge_interval(Ledger),
-    case peer_last_challenge(Address, Ledger) of
-        undefined ->
-            false;
-        LastChallenge when LastChallenge >= (Height - (2 * PoCInterval)) ->
-            true;
-        _ ->
-            false
     end.
 
 peer_time(Address, PeerBook) ->
@@ -64,27 +50,6 @@ peer_height(Address, PeerBook) ->
                 Other
             ]),
             undefined
-    end.
-
-peer_stale(Address, PeerBook, Refresh) ->
-    case libp2p_peerbook:get(PeerBook, Address) of
-        {ok, Peer} ->
-            case libp2p_peer:is_stale(Peer, ?STALE_PEER_TIME) of
-                true when Refresh ->
-                    libp2p_peerbook:refresh(PeerBook, Address),
-                    %% ARP should be quick so give it a short while
-                    timer:sleep(100),
-                    peer_stale(Address, PeerBook, false);
-                Stale ->
-                    Stale
-            end;
-        {error, _} when Refresh ->
-            libp2p_peerbook:refresh(PeerBook, Address),
-            %% ARP should be quick so give it a short while
-            timer:sleep(100),
-            peer_stale(Address, PeerBook, false);
-        _ ->
-            true
     end.
 
 -spec peer_listen_addrs(libp2p_crypto:pubkey_bin(), libp2p_peerbook:peerbook()) ->


### PR DESCRIPTION
The blockchain-http repo already had a workaround in place to return a hotpot status as online if the hotspots had any activity on chain.

This worked but would then not reflect in generated extracts or in city counts.

This PR updates the gateway_status.online column based on the same logic.. i.e.: A hotspot is _online_ if it has _any_ on chain activity in the last 36 hours of blocks (2160 blocks).

A side effect of this PR is that ARPs are no longer sent since we’re no longer interested in using the hotspot gossiped height as an indication of how far along it is. This is not a big deal _except_ that listen_addresses are no longer updated as frequently which will no longer matter with light hotspots around the corner