### PR TITLE
Updating README for erlang/OTP version (22 -> 24)

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,20 +12,20 @@ listening for new block events.
 
 To run blockchain-etl, you will need:
 
-* erlang 22 -- newer versions will not work
+* erlang 24 -- newer versions will not work
 * rust -- we recommend using [rustup](https://rustup.rs/)
 * postgresql + postgis
 
 Optionally you can geocode locations using the [Google Maps Geocoding API](https://developers.google.com/maps/documentation/geocoding/start).
 Register an API key and update `GOOGLE_MAPS_API_KEY=...` in your `.env.dev` file
 
-## Installing Erlang 22 on Ubuntu
+## Installing Erlang 24 on Ubuntu
 
 ```bash
 wget https://packages.erlang-solutions.com/erlang-solutions_2.0_all.deb
 sudo dpkg -i erlang-solutions_2.0_all.deb
 sudo apt-get update
-sudo apt install esl-erlang=1:22.3.4.1-1 cmake libsodium-dev libssl-dev build-essential
+sudo apt install esl-erlang=1:24.3.3-1 cmake libsodium-dev libssl-dev build-essential
 ```
 
 ## Developer Usage


### PR DESCRIPTION
With tag: 1.1.151, instances running on OTP 22 and 23 got stucked. OTP 24 is required from now on.