### PR TITLE
Avoid use of be_txn:to_json

### DIFF
--- a/src/be_db_pending_txn.erl
+++ b/src/be_db_pending_txn.erl
@@ -142,7 +142,9 @@ handle_info({submit_pending, Stmt}, State = #state{}) ->
     QUpdatePendingTxn = fun(TxnCreatedAt, _TxnHash, Txn, Acc) ->
         Fields =
             try
-                be_txn:to_json(Txn)
+                %% Do not use be_txn:to_json to avoid requiring ledger to get
+                %% more complete json output before it's time.
+                blockchain_txn:to_json(Txn, [])
             catch
                 _:_ -> null
             end,


### PR DESCRIPTION
be_txn:to_json requires use of ledger for a number of txns to add more relevant context. During txn submission that context is not relevant since the txn hasn’t been accepted by the chain yet. Use the basic blockchain_txn:to_json instead