### PR TITLE
Adding automation for building and publishing public Docker images.

### DIFF
--- a/.github/workflows/BuildAndPublishDocker.yml
+++ b/.github/workflows/BuildAndPublishDocker.yml
@@ -1,0 +1,41 @@
+name: Build & Publish Docker
+
+on:
+  push:
+    tags: [ "*.*.*" ] # Match tags in the format Helium uses for a release
+
+env:
+  REGISTRY: ghcr.io
+  IMAGE_NAME: ${{ github.repository }}
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v3
+
+    # Only needed for using multiple platforms later
+    - name: Setup Docker buildx
+      uses: docker/setup-buildx-action@79abd3f86f79a9d68a23c75a09a9a85889262adf
+
+    - name: Log into registry ${{ env.REGISTRY }}
+      uses: docker/login-action@28218f9b04b4f3f62068d7b6ce6ca5b26e35336c
+      with:
+        registry: ${{ env.REGISTRY }}
+        username: ${{ github.actor }}
+        password: ${{ secrets.GITHUB_TOKEN }}
+
+    - name: Extract Docker metadata
+      id: meta
+      uses: docker/metadata-action@98669ae865ea3cffbcbaa878cf57c20bbf1c6c38
+      with:
+        images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
+
+    - name: Build and push Docker image
+      id: build-and-push
+      uses: docker/build-push-action@ac9327eae2b366085ac7f6a2d02df8aa8ead720a
+      with:
+        context: .
+        push: true
+        platforms: linux/amd64,linux/arm64
+        tags: ${{ steps.meta.outputs.tags }}


### PR DESCRIPTION
This resolves #270 by creating a new Docker image and publishing it to the GitHub package repo. This may also resolve #265 by providing public containers when a release happens so users don't have to build their own.

This works off git tags and anytime an image is tagged in the format of x.y.z the workflow will be kicked off. I chose to use the GH package repo as to not interfere with any currently in-place systems with the quay.io hosting.

If you want an example repo to see how this works you can look at a personal repo of mine where I recently set this up.

[The workflow](https://github.com/HelixSpiral/apod-to-mqtt/blob/master/.github/workflows/docker.yml)
[The public packages that it builds](https://github.com/HelixSpiral/apod-to-mqtt/pkgs/container/apod-to-mqtt)